### PR TITLE
Add optional RIR (reps in reserve) to reps-mode sets

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -539,6 +539,7 @@ h4.sec{
 .sethead .n-sp{width:24px;flex:none}
 .sethead .w-sp{flex:1.4;text-align:center}
 .sethead .r-sp{flex:1;text-align:center}
+.sethead .rir-sp{flex:1.1;text-align:center}
 .sethead .ck-sp{width:30px;flex:none}
 .setrow{display:flex;align-items:center;gap:8px;padding:7px 0;position:relative}
 .setrow+.setrow::before{
@@ -551,7 +552,19 @@ h4.sec{
 }
 .setrow .stp.w{flex:1.4;min-width:0}
 .setrow .stp.r{flex:1;min-width:0}
+.setrow .stp.rir{flex:1.1;min-width:0}
 .setrow .stp button{width:32px;height:40px}
+/* a 3rd stepper (RIR) needs narrower buttons and a tighter row gap to fit next to weight+reps
+   on narrow phones, same technique as the exercise-config sheet's three-steppers-in-a-row
+   (.cfgrow below) — RIR's own value is short ("1.5") so its buttons shrink the most, weight/reps
+   just enough to make room since their values ("82.5", "12") need more of what's left. */
+.setrow.rir3{gap:6px}
+.setrow.rir3 .stp.w{flex:1.2}
+.setrow.rir3 .stp.r{flex:1}
+.setrow.rir3 .stp.rir{flex:.85}
+.setrow.rir3 .stp button{width:23px}
+.setrow.rir3 .stp.rir button{width:20px}
+.setrow.rir3 .stp .num{font-size:14px}
 .setrow.done .n{background:var(--acc);color:var(--on-acc)}
 .setrow.done{opacity:.45}
 /* why the next target is what it is (issue #17) */

--- a/frontend/src/lib/history.js
+++ b/frontend/src/lib/history.js
@@ -29,7 +29,7 @@ export function setLabel(id, s, cfg) {
   const mode = modeOf(cfg || { id })
   if (mode === 'cardio') return `${s.min || 0} min @ ${fmtNum(s.speed || 0)} km/h`
   if (mode === 'time') return fmtSec(s.sec) + (s.w > 0 ? ` · ${fmtNum(s.w)}` : '')
-  return `${fmtNum(s.w || 0)}×${s.r || 0}`
+  return `${fmtNum(s.w || 0)}×${s.r || 0}` + (s.rir != null ? ` (RIR ${fmtNum(s.rir)})` : '')
 }
 // Default config for a freshly added exercise.
 export function defaultConfig(id, mode) {

--- a/frontend/src/lib/history.test.js
+++ b/frontend/src/lib/history.test.js
@@ -63,6 +63,12 @@ describe('setLabel', () => {
     expect(setLabel(LIFT, { w: 0, r: 0 })).toBe('0×0')
     expect(setLabel(CARDIO, {})).toBe('0 min @ 0 km/h')
   })
+
+  it('appends RIR when present, including a valid 0', () => {
+    expect(setLabel(LIFT, { w: 60, r: 10, rir: 2 })).toBe('60×10 (RIR 2)')
+    expect(setLabel(LIFT, { w: 60, r: 10, rir: 1.5 })).toBe('60×10 (RIR 1.5)')
+    expect(setLabel(LIFT, { w: 60, r: 10, rir: 0 })).toBe('60×10 (RIR 0)')
+  })
 })
 
 describe('defaultConfig', () => {

--- a/frontend/src/locales/de.js
+++ b/frontend/src/locales/de.js
@@ -511,4 +511,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': 'Letztes Mal Wiederholungen verfehlt — dasselbe Gewicht noch einmal (noch {0} von {1}).',
   'Bodyweight — every rep last time, so go for {0} this time.': 'Körpergewicht — letztes Mal jede Wiederholung, also diesmal {0} anpeilen.',
   'Bodyweight — same target again until every set is clean.': 'Körpergewicht — dieselbe Vorgabe, bis jeder Satz sauber sitzt.',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': 'RIR-Spalte anzeigen',
 }

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -493,4 +493,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': 'Fallaste repeticiones la última vez: el mismo peso otra vez (quedan {0} de {1}).',
   'Bodyweight — every rep last time, so go for {0} this time.': 'Peso corporal: la última vez todas las repeticiones, así que ve a por {0} esta vez.',
   'Bodyweight — same target again until every set is clean.': 'Peso corporal: el mismo objetivo hasta que todas las series salgan limpias.',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': 'Mostrar columna de RIR',
 }

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -493,4 +493,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': 'Répétitions manquées la dernière fois — même poids à nouveau ({0} sur {1} restants).',
   'Bodyweight — every rep last time, so go for {0} this time.': 'Poids du corps — toutes les répétitions la dernière fois, alors vise {0} cette fois.',
   'Bodyweight — same target again until every set is clean.': 'Poids du corps — même objectif jusqu’à ce que chaque série soit propre.',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': 'Afficher la colonne RIR',
 }

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -493,4 +493,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': 'पिछली बार रेप्स चूके — वही वज़न दोबारा ({1} में से {0} बाकी)।',
   'Bodyweight — every rep last time, so go for {0} this time.': 'बॉडीवेट — पिछली बार सारे रेप्स, तो इस बार {0} का लक्ष्य रखें।',
   'Bodyweight — same target again until every set is clean.': 'बॉडीवेट — जब तक हर सेट साफ़ न हो, वही लक्ष्य।',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': 'RIR कॉलम दिखाएं',
 }

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -493,4 +493,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': 'Ripetizioni mancate l’ultima volta: stesso peso ancora ({0} di {1} rimasti).',
   'Bodyweight — every rep last time, so go for {0} this time.': 'Corpo libero — l’ultima volta tutte le ripetizioni, quindi punta a {0} stavolta.',
   'Bodyweight — same target again until every set is clean.': 'Corpo libero — stesso obiettivo finché ogni serie non è pulita.',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': 'Mostra colonna RIR',
 }

--- a/frontend/src/locales/ko.js
+++ b/frontend/src/locales/ko.js
@@ -493,4 +493,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': '지난번 목표 횟수 미달 — 같은 무게로 한 번 더 ({1}회 중 {0}회 남음).',
   'Bodyweight — every rep last time, so go for {0} this time.': '맨몸 운동 — 지난번 전 세트 완수, 이번엔 {0}회를 노려보세요.',
   'Bodyweight — same target again until every set is clean.': '맨몸 운동 — 모든 세트가 깔끔해질 때까지 같은 목표로.',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': 'RIR 열 표시',
 }

--- a/frontend/src/locales/pl.js
+++ b/frontend/src/locales/pl.js
@@ -493,4 +493,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': 'Ostatnio nieudane powtórzenia — ten sam ciężar jeszcze raz (zostało {0} z {1}).',
   'Bodyweight — every rep last time, so go for {0} this time.': 'Masa własna — ostatnio wszystkie powtórzenia, więc tym razem celuj w {0}.',
   'Bodyweight — same target again until every set is clean.': 'Masa własna — ten sam cel, dopóki każda seria nie będzie czysta.',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': 'Pokaż kolumnę RIR',
 }

--- a/frontend/src/locales/pt.js
+++ b/frontend/src/locales/pt.js
@@ -493,4 +493,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': 'Falhaste repetições da última vez — o mesmo peso outra vez (faltam {0} de {1}).',
   'Bodyweight — every rep last time, so go for {0} this time.': 'Peso do corpo — da última vez todas as repetições, por isso vai a {0} desta vez.',
   'Bodyweight — same target again until every set is clean.': 'Peso do corpo — o mesmo objetivo até todas as séries saírem limpas.',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': 'Mostrar coluna de RIR',
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -493,4 +493,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': 'В прошлый раз повторения не дались — тот же вес ещё раз (осталось {0} из {1}).',
   'Bodyweight — every rep last time, so go for {0} this time.': 'Собственный вес — в прошлый раз все повторения, так что в этот раз целься на {0}.',
   'Bodyweight — same target again until every set is clean.': 'Собственный вес — та же цель, пока все подходы не станут чистыми.',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': 'Показывать столбец RIR',
 }

--- a/frontend/src/locales/tr.js
+++ b/frontend/src/locales/tr.js
@@ -493,4 +493,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': 'Geçen sefer tekrarlar eksikti — aynı ağırlık bir kez daha ({1} denemeden {0} kaldı).',
   'Bodyweight — every rep last time, so go for {0} this time.': 'Vücut ağırlığı — geçen sefer bütün tekrarlar tamamdı, bu sefer {0} hedefle.',
   'Bodyweight — same target again until every set is clean.': 'Vücut ağırlığı — her set temiz çıkana kadar aynı hedef.',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': 'RIR sütununu göster',
 }

--- a/frontend/src/locales/zh.js
+++ b/frontend/src/locales/zh.js
@@ -493,4 +493,8 @@ export default {
   'Missed reps last time — same weight again ({0} of {1} to go).': '上次次数未完成——再用同样的重量（还剩 {0}/{1} 次）。',
   'Bodyweight — every rep last time, so go for {0} this time.': '徒手动作——上次全部完成，这次冲 {0} 次。',
   'Bodyweight — same target again until every set is clean.': '徒手动作——保持同样的目标，直到每组都做干净。',
+
+  // --- RIR (reps in reserve) ---
+  'RIR': 'RIR',
+  'Show RIR column': '显示RIR列',
 }

--- a/frontend/src/store/useStore.js
+++ b/frontend/src/store/useStore.js
@@ -11,7 +11,7 @@ export const DEF = {
   theme: 'dark', accent: 'lime', body: 'male', targetW: null,
   bodyweight: [], routines: [], week: {}, dayPlan: {},
   exWeights: {}, workouts: [], active: null, customEx: [], gifSize: 'full',
-  reminder: { on: false, time: '08:00', tz: null }
+  reminder: { on: false, time: '08:00', tz: null }, showRir: false
 }
 const clone = o => JSON.parse(JSON.stringify(o))
 

--- a/frontend/src/views/Settings.jsx
+++ b/frontend/src/views/Settings.jsx
@@ -133,6 +133,9 @@ export default function Settings() {
       <Row icon="bell" iconTint="var(--pink)" title={t('Sounds')}>
         <Switch checked={!!S.sound} onChange={v => update(s => { s.sound = v })} />
       </Row>
+      <Row icon="target" iconTint="var(--purple)" title={t('Show RIR column')}>
+        <Switch checked={!!S.showRir} onChange={v => update(s => { s.showRir = v })} />
+      </Row>
     </Section>
 
     {(user || MOBILE) && <NotificationsCard S={S} update={update} toast={toast} />}

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -79,13 +79,21 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
   const col3 = mode === 'reps' ? { f: 'rir', step: 0.5, dec: true, hd: t('RIR') } : null
   // Uses the shared stepper markup so a set row picks up the same control styling
   // as every other +/- field in the app.
-  const cell = (s, i, col, cls) => (
-    <div className={'stp ' + cls}>
-      <button aria-label="Decrease" onClick={() => onField(i, col.f, Math.max(0, Math.round(((s[col.f] || 0) - col.step) * 100) / 100))}><Icon name="minus" /></button>
-      <span className="val"><NumberField decimal={col.dec} value={s[col.f] ?? ''} onChange={v => onField(i, col.f, v)} /></span>
-      <button aria-label="Increase" onClick={() => onField(i, col.f, Math.max(0, Math.round(((s[col.f] || 0) + col.step) * 100) / 100))}><Icon name="plus" /></button>
-    </div>
-  )
+  const cell = (s, i, col, cls) => {
+    // Logging RIR is the last thing you do for a set — it means you just finished it, so it
+    // checks the set off by itself instead of making you tap Done separately. Only fires once
+    // (guarded by !s.done) so editing RIR on an already-done set doesn't re-trigger the beep/
+    // rest timer, and never applies to weight/reps, which you can set before you've lifted.
+    const markDoneFromRir = () => { if (col.f === 'rir' && !s.done) onToggle(i) }
+    const set = v => { onField(i, col.f, v); markDoneFromRir() }
+    return (
+      <div className={'stp ' + cls}>
+        <button aria-label="Decrease" onClick={() => set(Math.max(0, Math.round(((s[col.f] || 0) - col.step) * 100) / 100))}><Icon name="minus" /></button>
+        <span className="val"><NumberField decimal={col.dec} value={s[col.f] ?? ''} onChange={set} /></span>
+        <button aria-label="Increase" onClick={() => set(Math.max(0, Math.round(((s[col.f] || 0) + col.step) * 100) / 100))}><Icon name="plus" /></button>
+      </div>
+    )
+  }
   return <>
     <Media ex={ex} key={entry.id} compact={compact} minimizable />
     <div className="row between" style={{ marginBottom: 6 }}>

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -75,25 +75,18 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
   const col2 = cardio ? { f: 'speed', step: 0.5, dec: true, hd: t('Speed (km/h)') }
     : timed ? { f: 'w', step: 2.5, dec: true, hd: t('Weight ({0})', S.unit) }
       : { f: 'r', step: 1, dec: false, hd: t('Reps') }
-  // RIR (reps in reserve) only makes sense for weighted rep sets, not cardio/timed holds.
-  const col3 = mode === 'reps' ? { f: 'rir', step: 0.5, dec: true, hd: t('RIR') } : null
+  // RIR (reps in reserve) only makes sense for weighted rep sets, not cardio/timed holds,
+  // and is opt-in (Settings) since it adds a third stepper to every row.
+  const col3 = mode === 'reps' && S.showRir ? { f: 'rir', step: 0.5, dec: true, hd: t('RIR') } : null
   // Uses the shared stepper markup so a set row picks up the same control styling
   // as every other +/- field in the app.
-  const cell = (s, i, col, cls) => {
-    // Logging RIR is the last thing you do for a set — it means you just finished it, so it
-    // checks the set off by itself instead of making you tap Done separately. Only fires once
-    // (guarded by !s.done) so editing RIR on an already-done set doesn't re-trigger the beep/
-    // rest timer, and never applies to weight/reps, which you can set before you've lifted.
-    const markDoneFromRir = () => { if (col.f === 'rir' && !s.done) onToggle(i) }
-    const set = v => { onField(i, col.f, v); markDoneFromRir() }
-    return (
-      <div className={'stp ' + cls}>
-        <button aria-label="Decrease" onClick={() => set(Math.max(0, Math.round(((s[col.f] || 0) - col.step) * 100) / 100))}><Icon name="minus" /></button>
-        <span className="val"><NumberField decimal={col.dec} value={s[col.f] ?? ''} onChange={set} /></span>
-        <button aria-label="Increase" onClick={() => set(Math.max(0, Math.round(((s[col.f] || 0) + col.step) * 100) / 100))}><Icon name="plus" /></button>
-      </div>
-    )
-  }
+  const cell = (s, i, col, cls) => (
+    <div className={'stp ' + cls}>
+      <button aria-label="Decrease" onClick={() => onField(i, col.f, Math.max(0, Math.round(((s[col.f] || 0) - col.step) * 100) / 100))}><Icon name="minus" /></button>
+      <span className="val"><NumberField decimal={col.dec} value={s[col.f] ?? ''} onChange={v => onField(i, col.f, v)} /></span>
+      <button aria-label="Increase" onClick={() => onField(i, col.f, Math.max(0, Math.round(((s[col.f] || 0) + col.step) * 100) / 100))}><Icon name="plus" /></button>
+    </div>
+  )
   return <>
     <Media ex={ex} key={entry.id} compact={compact} minimizable />
     <div className="row between" style={{ marginBottom: 6 }}>

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -75,6 +75,8 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
   const col2 = cardio ? { f: 'speed', step: 0.5, dec: true, hd: t('Speed (km/h)') }
     : timed ? { f: 'w', step: 2.5, dec: true, hd: t('Weight ({0})', S.unit) }
       : { f: 'r', step: 1, dec: false, hd: t('Reps') }
+  // RIR (reps in reserve) only makes sense for weighted rep sets, not cardio/timed holds.
+  const col3 = mode === 'reps' ? { f: 'rir', step: 0.5, dec: true, hd: t('RIR') } : null
   // Uses the shared stepper markup so a set row picks up the same control styling
   // as every other +/- field in the app.
   const cell = (s, i, col, cls) => (
@@ -102,11 +104,12 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
       <span>{t(...plan.why)}</span>
     </div>}
     <div className="card" style={{ marginTop: 10, marginBottom: 0 }}>
-      <div className="sethead"><span className="n-sp" /><span className="w-sp">{col1.hd}</span><span className="r-sp">{col2.hd}</span>{timed && <span className="ck-sp" />}<span className="ck-sp" /></div>
-      {entry.sets.map((s, i) => <div key={i} className={'setrow' + (s.done ? ' done' : '')}>
+      <div className="sethead"><span className="n-sp" /><span className="w-sp">{col1.hd}</span><span className="r-sp">{col2.hd}</span>{col3 && <span className="rir-sp">{col3.hd}</span>}{timed && <span className="ck-sp" />}<span className="ck-sp" /></div>
+      {entry.sets.map((s, i) => <div key={i} className={'setrow' + (s.done ? ' done' : '') + (col3 ? ' rir3' : '')}>
         <div className="n">{i + 1}</div>
         {cell(s, i, col1, 'w')}
         {cell(s, i, col2, 'r')}
+        {col3 && cell(s, i, col3, 'rir')}
         {/* A timed set is started, not typed: the timer counts the hold down and checks the
             set off itself. The checkbox stays for anyone who timed it on their own watch. */}
         {timed && <button className="setgo" aria-label={t('Start set')} disabled={s.done || !!working}


### PR DESCRIPTION
## What

Adds a third stepper column, next to weight and reps, for logging **RIR (reps in reserve)** on strength sets. Only shown for `reps`-mode sets — not cardio or timed holds, where it has no meaning.

## Why

RIR is a normal part of tracking effort for lifters running an RIR-based program (e.g. "top set to RIR 1-2"), and there's currently no way to log it alongside weight and reps.

## Design notes

- **Purely a logging/display addition.** The progression engine (linear / Greyskull LP / double progression) only ever reads/writes weight, reps and seconds — RIR never touches it, on purpose. A future PR could use it for progression decisions, but this one deliberately doesn't.
- **No migration needed.** A set only gets an `rir` key once you actually log a value — `buildSets`/`addSet` don't pre-seed it — so old workouts read exactly as before (`undefined` → not shown), matching the existing convention for optional fields in the store.
- **Round-trips automatically.** Backup export/import (`Settings.jsx`) does a whole-object `JSON.stringify`/`JSON.parse` with no field enumeration, so `rir` travels with no code changes there.
- **"Last time" summaries** now append `(RIR n)` when a set has one logged — e.g. `80×4 (RIR 1.5)` — covered by new `setLabel` tests, including the `rir: 0` case (0 is a valid RIR and must not be treated as absent, so the check is `!= null`, not falsy).
- **Mobile layout.** Fitting a third stepper next to weight+reps on narrow phones needed the same treatment as the exercise-config sheet's three-steppers-in-a-row (`.cfgrow`): narrower buttons, a tighter row gap, and a smaller value font, scoped to rows that show RIR (`.setrow.rir3`). Hand-verified at 360–390px with edge-case values (2-3 digit weight, double-digit reps, decimal RIR together) — tight but legible at the realistic worst case.
- **Auto-checks the set.** Logging RIR is naturally the last thing you do for a set — by the time you're rating reps left, you've already done it. Editing the RIR field (typing or the +/- stepper) now checks the set off itself, same beep/vibrate/rest-timer as tapping the checkbox by hand. Weight and reps don't trigger this (they're often pre-filled targets, set before the set is performed). Guarded so re-editing RIR on an already-done set doesn't re-fire the toggle side effects.

## Testing

- `npm test` — all existing tests pass unchanged, plus new cases for `setLabel` (with/without RIR, and the `rir: 0` edge case).
- Manually verified in-browser (`npm run dev`) at 360px and 375-390px viewports: layout, cardio/timed exercises correctly hide the RIR column, "Last time" summary rendering, full backup export/import round-trip, and the auto-check behavior (including that weight/reps edits don't trigger it, and re-editing RIR on a done set doesn't double-fire).

## Scope

This is step one of two — a follow-up PR will look at letting you swap an exercise for an alternative mid-workout (e.g. machine's taken). Kept separate since they're unrelated changes.