### PR TITLE
Coach: put coach/ in the api image, which never had it

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install --omit=dev && npm cache clean --force
 COPY server.js ./
+COPY coach ./coach
 ENV NODE_ENV=production
 EXPOSE 3000
 CMD ["node", "server.js"]


### PR DESCRIPTION
**One line, ahead of 3/6, because the branch tip currently ships an api container that exits on boot.**

`server.js` has statically imported `./coach/config.js` since 1/6. `api/Dockerfile` copies `server.js` and nothing else. So the image has no `/app/coach` in it at all:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/coach/config.js' imported from /app/server.js
```

Reproduced rather than reasoned about — built `api/` at `9082ac5` and ran it:

```
$ docker run --rm opengym-api-headtest sh -c 'ls /app/coach'
ls: /app/coach: No such file or directory
```

With this line, the same build boots and answers:

```
gym-api on :3000 (rpID=localhost, origin=http://localhost:8080)
$ curl -s localhost:3000/api/config
{"invite_only":false}
```

(`coach` absent from that payload is correct — the feature is off until an admin enables it.)

## Why it got through

Mine, from 1/6. The line existed while I was working; 1/6 staged its files by name because this branch carries upstream's `.gitignore` and my local tooling shows as untracked, and this one was not on the list.

Nothing caught it because the `api` job runs `node:test` against the **source tree**, where `coach/` is obviously present. There is no job that builds the image, and none that runs it. Your point on 1/6 was that none of this code had ever been run by anything except me — this is the same failure one layer out: the image had never been run by anything at all.

## What 3/6 does about it properly

3/6 rewrites this Dockerfile into the multi-stage form the optional Claude runtime needs — default target byte-identical to today's image, a `coach` target that adds the runtime — and adds the `api-image` job. That job builds **and starts** the container and asserts it answers `/api/config`, so "the image boots" becomes something CI knows rather than something we assume. Both targets, since the bug was in the shared layer.

Keeping that out of here on purpose: this is the one line that makes the current tip runnable, and it should be reviewable in ten seconds.
