### PR TITLE
Coach 4/6: the screens, and the four things they were supposed to say

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,3 +61,45 @@ jobs:
       # that forgets to regenerate it would otherwise only surface as "the Coach can't find
       # that exercise" on somebody's instance.
       - run: node scripts/build-coach-library.mjs --check
+
+  # Builds *and runs* both image targets. Building alone would not have caught the api image
+  # shipping without coach/ — that image built perfectly and exited on boot. So each target has
+  # to answer for itself: the default one starts and serves, and the coach one additionally
+  # resolves the Agent SDK's per-platform runtime (musl on this base), which is the one thing
+  # that cannot be checked from the source tree.
+  api-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - run: docker build --target default -t opengym-api:default ./api
+      - run: docker build --target coach   -t opengym-api:coach   ./api
+
+      - name: the default image boots and serves, with no AI runtime in it
+        run: |
+          docker run -d --name api-default -e DATA_DIR=/data -p 3000:3000 opengym-api:default
+          for i in $(seq 1 30); do
+            curl -fsS http://localhost:3000/api/config >/dev/null 2>&1 && break
+            sleep 1
+          done
+          curl -fsS http://localhost:3000/api/config | tee /dev/stderr | grep -q '"invite_only"'
+          # Absent by construction, not by accident: --omit=optional is the only thing keeping
+          # the AI dependency out of the image an owner gets when they never asked for it.
+          docker run --rm opengym-api:default node -e \
+            'import("@anthropic-ai/claude-agent-sdk").then(()=>{console.error("AI runtime present in the default image");process.exit(1)},()=>process.exit(0))'
+          docker rm -f api-default
+
+      - name: the coach image carries a runnable Agent SDK
+        run: |
+          docker run --rm opengym-api:coach node --input-type=module -e '
+            const { adapterFor } = await import("./coach/adapters/index.js");
+            const r = await adapterFor("claude").check();
+            if (!r.ok) { console.error(r.error); process.exit(1); }
+            console.log(r.version);
+          '
+
+      - name: the privilege drop can actually be performed in the image
+        run: |
+          # canDropPrivileges() fails closed, so a missing `coach` user disables every job —
+          # including the fixture provider. Cheaper to assert here than to discover on an instance.
+          docker run --rm opengym-api:default id coach

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install --omit=dev && npm cache clean --force
 COPY server.js ./
+COPY coach ./coach
 ENV NODE_ENV=production
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,9 +1,47 @@
-FROM node:22-alpine
+# Two targets from one file.
+#
+#   default (built when no --target is given) — what every instance has always got. No AI
+#           runtime, no AI dependency: `npm ci --omit=optional` skips the Agent SDK and its
+#           platform runtime entirely, so an owner who never wanted the Coach carries none of it.
+#   coach                                     — the same image plus the Claude Agent SDK.
+#
+# Build the opt-in one with:  docker build --target coach ./api
+# or through compose with:    API_TARGET=coach docker compose up --build
+#
+# The stage order matters: Docker builds the *last* stage when none is named, so `default` is
+# deliberately last and `coach` sits above it.
+
+FROM node:22-alpine AS base
 WORKDIR /app
+
+# The unprivileged user Coach jobs drop to. Its uid cannot read /data, which is the control that
+# keeps a provider runtime away from users, passkeys and the session secret.
+#
+# Not optional, and not only for the real providers: canDropPrivileges() fails closed on Linux,
+# so in an image without this user *every* job is refused with "no `coach` user exists in this
+# image" — including the fixture provider that exists precisely so the loop can be walked before
+# an account is connected. It costs one line and no bytes worth measuring.
+RUN adduser -D -H -s /sbin/nologin coach
+
 COPY package.json package-lock.json* ./
-RUN npm install --omit=dev && npm cache clean --force
+# `npm ci` rather than `npm install`: the lockfile is the point of committing one, and the SDK's
+# per-platform runtime is resolved from it (musl on this base) rather than from whatever the
+# build host happened to be.
+RUN npm ci --omit=dev --omit=optional && npm cache clean --force
+
 COPY server.js ./
 COPY coach ./coach
 ENV NODE_ENV=production
 EXPOSE 3000
 CMD ["node", "server.js"]
+
+# ---------------------------------------------------------------------------------------------
+# The opt-in target. Dropping --omit=optional is the whole difference: it pulls in
+# @anthropic-ai/claude-agent-sdk together with the one platform runtime this base needs
+# (linux-*-musl), both pinned by the lockfile.
+FROM base AS coach
+RUN npm ci --omit=dev && npm cache clean --force
+
+# ---------------------------------------------------------------------------------------------
+# Last, so that a plain `docker build ./api` keeps producing the runtime-free image.
+FROM base AS default

--- a/api/coach/adapters/claude.js
+++ b/api/coach/adapters/claude.js
@@ -1,0 +1,141 @@
+/* Claude Agent SDK adapter.
+ *
+ * Deliberately the SDK rather than a hand-rolled `claude --print`: it brings its own matching
+ * runtime, takes the owner's credential only through the child environment, and exposes the
+ * switches that keep the model in a text-in / JSON-out lane.
+ *
+ * Four of those switches are why this adapter can be trusted next to somebody's ./data, and
+ * each is a documented option rather than a hopeful one:
+ *
+ *   tools: []          — "Disable all built-in tools" (SDK Options). No Read, no Bash, no Grep;
+ *                        the model has no filesystem tool at all, however it is prompted.
+ *   settingSources: [] — no user/project/local settings file is loaded, so nothing on the host
+ *                        can widen the line above after the fact.
+ *   skills: []         — same reasoning, for skills.
+ *   strictMcpConfig    — no MCP server can arrive from ambient config.
+ *
+ * They are exported as LOCKDOWN and asserted by value in adapters.test.js, so re-enabling one
+ * is a red build rather than a quiet capability grant.
+ *
+ * The import is lazy on purpose. The default image ships without the SDK (see api/Dockerfile),
+ * and an absent runtime has to be an ordinary reportable state — check() says so, isConnected()
+ * goes false, and no Coach UI is mounted — rather than a boot crash for every instance that
+ * never asked for the feature.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { unprivilegedIds } from './spawn.js';
+
+const PKG = '@anthropic-ai/claude-agent-sdk';
+const require_ = createRequire(import.meta.url);
+// Read rather than hardcoded: the fork's copy still identified itself as 1.2.3 two releases
+// later, which is the failure mode of every version string typed by hand.
+const CLIENT_APP = `opengym-coach/${(() => {
+  try { return require_('../../package.json').version; } catch { return '0' }
+})()}`;
+const OUTPUT_CAP = 4 * 1024 * 1024;
+const SYSTEM_PROMPT = [
+  'You are the openGym Coach.',
+  'Answer only the supplied task and return exactly the requested JSON.',
+  'You have no tools, filesystem access, external services, or persistent memory.'
+].join(' ');
+
+/** The options that make this adapter safe. Exported so a test can assert them by value. */
+export const LOCKDOWN = Object.freeze({
+  tools: [],
+  settingSources: [],
+  skills: [],
+  strictMcpConfig: true,
+  persistSession: false,
+  permissionMode: 'dontAsk',
+  maxTurns: 1
+});
+
+let cached;
+/** Resolve the SDK, or null when this image was built without it. Never throws. */
+async function sdk() {
+  if (cached !== undefined) return cached;
+  try { cached = await import(PKG); } catch { cached = null; }
+  return cached;
+}
+
+/* The package does not expose ./package.json through its exports map, so ask the resolver where
+   the entry point landed and read the manifest sitting next to it. Best-effort by design: the
+   admin card shows the version when it can be had, and "installed" is a fine answer when not. */
+function installedVersion() {
+  try {
+    const entry = fileURLToPath(import.meta.resolve(PKG));
+    return JSON.parse(fs.readFileSync(path.join(path.dirname(entry), 'package.json'), 'utf8')).version || null;
+  } catch { return null; }
+}
+
+/* The SDK owns the protocol; the Coach still owns the process boundary. Its runtime is launched
+   as the same unprivileged `coach` user as every other provider, so dropping privileges is not
+   something an adapter can forget to do. */
+function spawnAsCoach({ command, args, cwd, env, signal }) {
+  const ids = unprivilegedIds();
+  return spawn(command, args, { cwd, env, signal, stdio: ['pipe', 'pipe', 'pipe'], ...(ids || {}) });
+}
+
+export default {
+  id: 'claude',
+  runtime: 'Claude Agent SDK',
+
+  /* Importing the package is the check: it is exactly what a job will do, and it is the one
+     difference between the two build targets. The credential is deliberately not probed here —
+     that is testRun()'s job, which does a real round trip rather than inspecting a token this
+     module never reads. */
+  async check() {
+    const m = await sdk();
+    if (!m) return { ok: false, error: `the Claude runtime is not installed in this image (${PKG})` };
+    const v = installedVersion();
+    return { ok: true, version: v ? `Claude Agent SDK ${v}` : 'Claude Agent SDK' };
+  },
+
+  async invoke({ prompt, jobDir, env, model, timeoutMs }) {
+    const m = await sdk();
+    if (!m) return { code: -1, text: '', stderr: `${PKG} is not installed`, timedOut: false, spawnError: true };
+
+    let text = '', stderr = '', failure = '', timedOut = false;
+    const abortController = new AbortController();
+    const timer = setTimeout(() => { timedOut = true; abortController.abort(); }, timeoutMs);
+
+    try {
+      for await (const message of m.query({
+        prompt,
+        options: {
+          ...LOCKDOWN,
+          abortController,
+          cwd: jobDir,
+          // `env` REPLACES the child environment rather than extending it — which is exactly the
+          // contract config.jobEnv() was written to. It builds from nothing, so RP_ID, ADMIN_UIDS
+          // and the VAPID keys cannot reach the model process by inheritance.
+          env: { ...env, CLAUDE_AGENT_SDK_CLIENT_APP: CLIENT_APP },
+          model: model || undefined,
+          systemPrompt: SYSTEM_PROMPT,
+          stderr: data => { if (stderr.length < OUTPUT_CAP) stderr += data; },
+          spawnClaudeCodeProcess: spawnAsCoach
+        }
+      })) {
+        if (message.type !== 'result') continue;
+        if (message.subtype === 'success') text = message.result;
+        // A non-success result carries its reason in `subtype` (error_during_execution,
+        // error_max_turns, …) and `stop_reason`. There is no error list on it — do not invent one.
+        else failure = `the Agent SDK stopped: ${message.subtype}${message.stop_reason ? ` (${message.stop_reason})` : ''}`;
+      }
+    } catch (e) {
+      if (timedOut) return { code: -1, text: '', stderr: 'the Agent SDK timed out', timedOut: true, spawnError: false };
+      return { code: -1, text: '', stderr: stderr || (e instanceof Error ? e.message : String(e)), timedOut: false, spawnError: true };
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (timedOut) return { code: -1, text: '', stderr: 'the Agent SDK timed out', timedOut: true, spawnError: false };
+    if (failure) return { code: 1, text: '', stderr: failure, timedOut: false, spawnError: false };
+    if (!text) return { code: 1, text: '', stderr: stderr || 'the Agent SDK returned no result', timedOut: false, spawnError: false };
+    return { code: 0, text, stderr, timedOut: false, spawnError: false };
+  }
+};

--- a/api/coach/adapters/index.js
+++ b/api/coach/adapters/index.js
@@ -7,6 +7,7 @@
  * codebase — routes, jobs, payload, validation, UI — knows which one is configured.
  */
 import { run } from './spawn.js';
+import claude from './claude.js';
 
 /**
  * The in-repo fake provider. Ships with the image on purpose: it is what CI drives, and it
@@ -29,6 +30,9 @@ const fixture = {
   }
 };
 
-const ADAPTERS = { fixture };
+/* claude is registered unconditionally, and that is safe because claude.js imports the SDK
+   lazily: on the default image the module loads, check() reports the runtime as absent, and
+   isConnected() keeps the Coach out of /api/config entirely. Codex arrives with 6/6. */
+const ADAPTERS = { fixture, claude };
 export const adapterFor = provider => ADAPTERS[provider] || null;
 export default ADAPTERS;

--- a/api/coach/config.js
+++ b/api/coach/config.js
@@ -34,7 +34,15 @@ export const COACH_DISABLED = /^(1|true|yes|on)$/i.test(process.env.COACH_DISABL
 // providers arrive with their adapters; this PR ships only the in-repo fixture, so an instance
 // can be exercised end to end without an AI account.
 export const PROVIDERS = {
-  fixture: { label: 'Fixture (testing)', runtime: 'Fixture', apiKeyEnv: null, oauthEnv: null }
+  fixture: { label: 'Fixture (testing)', runtime: 'Fixture', apiKeyEnv: null, oauthEnv: null },
+  // `apiKeyEnv` / `oauthEnv` name the variable jobEnv injects the credential as; the runtime
+  // reads it from its environment and from nothing else, which is what makes the sanitised env
+  // the only channel a credential can travel down. `claude setup-token` mints the long-lived
+  // token that rides in CLAUDE_CODE_OAUTH_TOKEN — hence setupToken rather than a device login.
+  claude: {
+    label: 'Claude (Anthropic)', runtime: 'Claude Agent SDK',
+    apiKeyEnv: 'ANTHROPIC_API_KEY', oauthEnv: 'CLAUDE_CODE_OAUTH_TOKEN', setupToken: true
+  }
 };
 
 const DEFAULTS = {

--- a/api/coach/routes.js
+++ b/api/coach/routes.js
@@ -120,6 +120,18 @@ export function coachRoutes({ json, readBody, readSession, requireAdmin }) {
         runtime: { ok: !!check.ok, version: check.version || null, error: check.error || null },
         authMode: cfg.authMode,
         boundUid: cfg.boundUid || null,
+        /* Whether a credential is filed, and whose — never the credential. `unreadable` is its
+           own state rather than "not connected" because it has a specific cause and a specific
+           fix: ./data was restored without its `secret`, so the blob is intact and undecryptable,
+           and connecting again is the way out. */
+        auth: (() => {
+          if (!cfgStore.providerMeta(cfg).oauthEnv && !cfgStore.providerMeta(cfg).apiKeyEnv) {
+            return { state: 'not-required' };
+          }
+          if (!cfg.auth || !cfg.auth.data) return { state: 'none' };
+          if (!cfgStore.decrypt(cfg.auth.data)) return { state: 'unreadable' };
+          return { state: 'connected', type: cfg.auth.type || null, account: cfg.auth.account || null };
+        })(),
         // Whether the privilege drop can actually be performed. Surfaced because the control
         // now fails closed: if this reads false, no job runs, and the admin needs to know that
         // from the card rather than from a user reporting that nothing happens.

--- a/api/coach/routes.js
+++ b/api/coach/routes.js
@@ -160,11 +160,45 @@ export function coachRoutes({ json, readBody, readSession, requireAdmin }) {
       json(res, 200, r);
     },
 
-    /* The gap here is `authMode` and connect/clear-credential, and it lands with PR 3 rather
-       than in this file today. Both exist to serve a credential, and the only provider this
-       build ships is the fixture, which has none: `credentialFor` returns before it consults
-       the mode. A switch whose two positions do the same thing is worse than no switch — so it
-       arrives with the setup-token path, in the PR that gives it something to switch between. */
+    /* Connect the instance credential. Deferred while the fixture was the only provider — it
+       has none, so there was nothing to connect. The real providers give it something to hold,
+       which is the condition this route was waiting on.
+
+       The token is accepted once and never read back: it is encrypted here and leaves again
+       only as an environment variable on a job's child process. `type` has to match a variable
+       the configured provider actually declares, so a Codex key cannot be filed under Claude
+       and then silently go nowhere at job time. */
+    'POST /api/admin/coach/connect': async (req, res) => {
+      if (!requireAdmin(req, res)) return;
+      const body = await readBody(req);
+      const cfg = cfgStore.load();
+      const meta = cfgStore.providerMeta(cfg);
+      const type = String(body.type || '');
+      const envVar = (type === 'cli-token' || type === 'oauth') ? meta.oauthEnv
+        : type === 'apikey' ? meta.apiKeyEnv : null;
+      if (!envVar) {
+        return json(res, 400, { error: `${cfg.provider} does not take a credential of type "${type}"` });
+      }
+      const token = String(body.token || '').trim();
+      if (!token) return json(res, 400, { error: 'no token supplied' });
+      // boundUid resets with the credential: a new account has not been spent by anyone yet.
+      cfgStore.save({
+        auth: { type, account: String(body.account || '').slice(0, 120), data: cfgStore.encrypt({ token }) },
+        boundUid: null
+      });
+      json(res, 200, { ok: true });
+    },
+
+    'POST /api/admin/coach/disconnect': async (req, res) => {
+      if (!requireAdmin(req, res)) return;
+      cfgStore.save({ auth: null, boundUid: null });
+      json(res, 200, { ok: true });
+    },
+
+    /* Still absent: `authMode`, and with it the per-profile credential routes. Instance mode is
+       the whole of what these two routes serve, and per-profile needs its own connect/clear pair
+       against saveProfileAuth/clearProfileAuth — a switch with nothing on the other side is worse
+       than no switch, so it waits for the PR that builds that side. */
 
     /* Whose account this profile is about to spend. Its own route because both the Coach screen
        and the admin card must state it, and neither should be inferring it from settings. */

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,16 +1,194 @@
 {
   "name": "gym-api",
-  "version": "1.0.0",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gym-api",
-      "version": "1.0.0",
+      "version": "1.2.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@simplewebauthn/server": "^13.1.1",
         "web-push": "^3.6.7"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.223"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.223",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.223.tgz",
+      "integrity": "sha512-r2BpOfxaEjPj0xpRQBukrBWG7n2QERVk10hstc+AXmm4JBii1OqH50sfewU8a8E7uhoJazA3WnZoZoaTFnV/2A==",
+      "license": "SEE LICENSE IN README.md",
+      "optional": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.223",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.223",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.223",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.223",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.223",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.223",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.223",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.223"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.223",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.223.tgz",
+      "integrity": "sha512-y9PcAkK7JHfzBC1yyLIhJwlF/x7XYLcFReiKkxm53mtBp+ASgpxNoBDvGqx7Q+IVB5xwlhnprcaXc2PxsLUKuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.223",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.223.tgz",
+      "integrity": "sha512-JAkGQCat4FroNdG9XQiKQ+M+R/mggt3fFVQR5KcsbOrGFNynCdnVhi9CPxU8AXDhiIbk+Y3254qHhKTZbcZtGw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.223",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.223.tgz",
+      "integrity": "sha512-mFPm66MIiFtb/XiHR39/ifzv0nlho1KNCjH+1cP6lJvVXm57kugxsKDndGXWEBI0Wh7DxKhTnjRxEKVhwwdYWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.223",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.223.tgz",
+      "integrity": "sha512-HKpj+0quFtaH/fXQm56HipslOyhyTdB2vM4nvxmG3oube2KtB9FNJqqnTwSTeGbJc5dm4PjoAyN+oQV8Rh4RGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.223",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.223.tgz",
+      "integrity": "sha512-8x+BvnuNr8iTMqwBAf0KvklF/GRLXYiXMb+umo+N2bxOlE7wFYpFqVACeW44KsfRgdnbVnF9sJ00w1s01W/9eA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.223",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.223.tgz",
+      "integrity": "sha512-ukw6GAneAsCc/Lp24cA4yk2/vPgDjooZGB/TTvLsyfy8yto3b/WpfaktubQE/tNigF+mWo6+VytUOeVil8HwnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.223",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.223.tgz",
+      "integrity": "sha512-Am8q5al0BBIbxOlfLSjaXQqCOjOg/4XvCiSt8mxvocGy/6W60fV/RFrEs86RlN6DATUGxTSNTqye6cn8MTlgOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.223",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.223.tgz",
+      "integrity": "sha512-ZG53F8YtUTr97OGdnIbSqHuRHL1eja928M1xwbuAiM1cJ5I8VpFODVjHpM0ioKiurr9Tmjzns/nHcafc18VovA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+      "integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@hexagon/base64": {
@@ -18,10 +196,66 @@
       "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
       "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@levischuck/tiny-cbor": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
       "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@peculiar/asn1-android": {
       "version": "2.8.0",
@@ -196,12 +430,72 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/asn1.js": {
@@ -233,10 +527,178 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -254,6 +716,33 @@
         }
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -262,12 +751,383 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http_ece": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
       "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -282,10 +1142,108 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -306,6 +1264,75 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -324,6 +1351,127 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pvtsutils": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
@@ -340,10 +1488,89 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -369,6 +1596,210 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -390,6 +1821,63 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/web-push": {
       "version": "3.6.7",
       "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
@@ -406,6 +1894,53 @@
       },
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/api/package.json
+++ b/api/package.json
@@ -12,5 +12,8 @@
   "dependencies": {
     "@simplewebauthn/server": "^13.1.1",
     "web-push": "^3.6.7"
+  },
+  "optionalDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.223"
   }
 }

--- a/api/test/adapters.test.js
+++ b/api/test/adapters.test.js
@@ -1,0 +1,52 @@
+/* The provider adapters, and the four options that make the Claude one safe.
+ *
+ * These assertions are deliberately about the object the adapter passes to the SDK rather than
+ * about observed model behaviour: the point is that re-enabling a tool is a red build, and a
+ * test that needed a real account to run would never guard anything in CI.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { tempData } from './helpers.mjs';
+
+tempData();
+const { adapterFor, default: ADAPTERS } = await import('../coach/adapters/index.js');
+const { LOCKDOWN } = await import('../coach/adapters/claude.js');
+const cfg = await import('../coach/config.js');
+
+test('every provider the config offers has an adapter, and vice versa', () => {
+  assert.deepEqual(Object.keys(ADAPTERS).sort(), Object.keys(cfg.PROVIDERS).sort());
+  for (const id of Object.keys(cfg.PROVIDERS)) assert.ok(adapterFor(id), `no adapter for "${id}"`);
+  assert.equal(adapterFor('not-a-provider'), null);
+});
+
+test('the Claude adapter is locked out of every tool the SDK could give it', () => {
+  // `tools: []` is the SDK's documented "disable all built-in tools" — no Read, no Bash, no
+  // Grep — and the other three stop anything on the host widening that afterwards. If one of
+  // these ever has to change, it should be a decision with a diff, not a default that drifted.
+  assert.deepEqual(LOCKDOWN.tools, [], 'no built-in tools');
+  assert.deepEqual(LOCKDOWN.settingSources, [], 'no settings files may be loaded');
+  assert.deepEqual(LOCKDOWN.skills, [], 'no skills may be loaded');
+  assert.equal(LOCKDOWN.strictMcpConfig, true, 'no MCP server may arrive from ambient config');
+  assert.equal(LOCKDOWN.persistSession, false, 'no session history is written anywhere');
+  assert.equal(LOCKDOWN.maxTurns, 1, 'one turn: a job is a question, not a conversation');
+});
+
+test('an image built without the AI runtime reports it rather than crashing', async () => {
+  // The default build target has no SDK. check() is what the admin card renders, and it has to
+  // answer honestly on both targets — this asserts the shape either way, so the test is not
+  // hostage to which target the suite happens to run on.
+  const r = await adapterFor('claude').check();
+  assert.equal(typeof r.ok, 'boolean');
+  if (r.ok) assert.match(r.version, /Claude Agent SDK/);
+  else assert.match(r.error, /not installed/);
+});
+
+test('the fixture provider needs no credential and the Claude one names both it accepts', () => {
+  assert.equal(cfg.PROVIDERS.fixture.apiKeyEnv, null);
+  assert.equal(cfg.PROVIDERS.fixture.oauthEnv, null);
+  // The two variables the runtime reads. jobEnv() injects the credential under one of them and
+  // nothing else, which is what makes the sanitised environment the only channel it travels.
+  assert.equal(cfg.PROVIDERS.claude.oauthEnv, 'CLAUDE_CODE_OAUTH_TOKEN');
+  assert.equal(cfg.PROVIDERS.claude.apiKeyEnv, 'ANTHROPIC_API_KEY');
+  assert.equal(cfg.PROVIDERS.claude.setupToken, true);
+});

--- a/api/test/credential.test.js
+++ b/api/test/credential.test.js
@@ -135,11 +135,16 @@ test('jobEnv only ever carries the credential it was handed', () => {
   assert.equal(env.HOME, '/tmp/job');
   assert.equal(env.TMPDIR, '/tmp/job');
   // Built from nothing: no RP_ID, no ADMIN_UIDS, no VAPID material, nothing this server holds.
+  // The one permitted addition is the configured provider's own credential variable — read off
+  // the row rather than hardcoded, so this keeps testing the contract if that name ever changes.
+  // connectInstance() files a `cli-token`, which jobEnv injects under the provider's oauthEnv.
+  const expected = [cfg.providerMeta(cfg.load()).oauthEnv].filter(Boolean);
   assert.deepEqual(
     Object.keys(env).filter(k => !['PATH', 'HOME', 'TMPDIR'].includes(k)).sort(),
-    [],
-    'the fixture provider declares no credential env var, so nothing else may appear'
+    expected,
+    'only the credential the job was handed may appear, under its provider\'s own variable'
   );
+  if (expected.length) assert.equal(env[expected[0]], 'tok-for-env');
 
   const none = cfg.jobEnv('/tmp/job', { ok: false });
   assert.equal(Object.values(none).some(v => String(v).includes('tok-for-env')), false);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,14 @@ services:
   # image: prebuilt (docker compose pull). build: from source (docker compose up --build).
   api:
     image: ghcr.io/duartesantos8/opengym-api:latest
-    build: ./api
+    # Default target: no AI runtime, no AI dependency — the image every instance has always had.
+    # To opt into the AI Coach, build the other target instead:
+    #     API_TARGET=coach docker compose up --build api
+    # `--build` matters: with an `image:` also set, compose would otherwise pull the prebuilt
+    # default rather than build the coach one.
+    build:
+      context: ./api
+      target: ${API_TARGET:-default}
     restart: unless-stopped
     env_file: .env
     environment:

--- a/docs/AI_COACH.md
+++ b/docs/AI_COACH.md
@@ -4,8 +4,8 @@ An optional AI that **designs** a training plan and **revises it from what you a
 running on your own server under your own provider account, off until an admin turns it on.
 
 > This document grows with the feature. What is described here is what has landed: the server
-> plumbing, the consent and payload boundary, the credential model, and the validator and apply
-> path. The provider adapters and the UI arrive in the PRs that follow.
+> plumbing, the consent and payload boundary, the credential model, the validator and apply
+> path, and the Claude provider with its opt-in packaging. The UI arrives in the PRs that follow.
 
 ---
 
@@ -129,6 +129,54 @@ The secrets are locked file by file — `secret`, `db.json`, `coach.json` at `06
 by sealing `./data` with a blanket `0700`. The directory is a host bind mount and the container
 runs as root, so sealing it lands on the host as root-owned and unreadable, and anything else
 the owner runs against their own data directory gets `EACCES`.
+
+## You only carry the AI runtime if you ask for it
+
+`api/Dockerfile` builds two targets from one file:
+
+- **`default`** — what every instance has always had. `npm ci --omit=optional` skips the Agent
+  SDK and its platform runtime entirely, so an owner who never wanted the Coach ships none of it.
+  Around 158 MB.
+- **`coach`** — the same image plus `@anthropic-ai/claude-agent-sdk`. Around 455 MB.
+
+```
+docker build --target coach ./api          # or:
+API_TARGET=coach docker compose up --build api
+```
+
+The SDK sits in `optionalDependencies`, and its runtime ships as a per-platform package — this
+base is Alpine, so the lockfile resolves `linux-x64-musl` / `linux-arm64-musl`. That resolution
+is the sort of thing that only fails on somebody else's machine, so CI builds **and runs** both
+targets: the default one has to boot and serve `/api/config` with the SDK genuinely unimportable,
+and the coach one has to report a runnable SDK through the same `check()` the admin card renders.
+
+An absent runtime is an ordinary state, not a crash: the adapter imports the SDK lazily, `check()`
+says it is missing, `isConnected()` goes false, and `/api/config` carries no `coach` key at all.
+
+Both targets create the unprivileged `coach` user. That is not a Claude-specific detail — the
+privilege drop fails closed, so without that user *every* job is refused, including the fixture
+provider that exists precisely so the loop can be walked before an account is connected.
+
+## What the model is allowed to do
+
+The Claude provider runs through the Agent SDK rather than a hand-rolled CLI call, because the
+SDK exposes the switches that matter and brings its own matching runtime. Four of them are the
+reason it can be trusted next to your `./data`:
+
+| Option | Effect |
+| --- | --- |
+| `tools: []` | Disables **all** built-in tools — no Read, no Bash, no Grep. The model has no filesystem tool at all, however it is prompted. |
+| `settingSources: []` | No user/project/local settings file is loaded, so nothing on the host can widen the line above afterwards. |
+| `skills: []` | Same, for skills. |
+| `strictMcpConfig` | No MCP server can arrive from ambient configuration. |
+
+They are exported as one frozen object and asserted by value in `adapters.test.js`, so
+re-enabling one is a red build rather than a quiet capability grant.
+
+The credential reaches the model process as an environment variable and by no other route. The
+job environment is built from nothing rather than filtered, and the SDK's `env` option *replaces*
+the child environment rather than extending it — so `RP_ID`, `ADMIN_UIDS` and the VAPID keys
+cannot reach it by inheritance even by accident.
 
 ## Off is really off
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,9 @@ import History from './views/History.jsx'
 import Library from './views/Library.jsx'
 import Settings from './views/Settings.jsx'
 import Admin from './views/Admin.jsx'
+import Coach from './views/Coach.jsx'
+import CoachIntake from './views/CoachIntake.jsx'
+import CoachProposal from './views/CoachProposal.jsx'
 
 bindUI(useUI)   // lets the shared controls open sheets without importing the store at module scope
 
@@ -75,6 +78,12 @@ function Shell() {
               <Route path="/history" element={<History />} />
               <Route path="/library" element={<Library />} />
               <Route path="/settings" element={<Settings />} />
+              {/* The Coach screens gate themselves on the instance config; the routes exist
+                  unconditionally so a deep link from a notification lands somewhere sane
+                  rather than on the catch-all. */}
+              <Route path="/coach" element={<Coach />} />
+              <Route path="/coach/intake" element={<CoachIntake />} />
+              <Route path="/coach/proposal" element={<CoachProposal />} />
               <Route path="/admin" element={user?.admin ? <Admin /> : <Navigate to="/home" replace />} />
               <Route path="*" element={<Navigate to="/home" replace />} />
             </Routes>

--- a/frontend/src/lib/coach-api.js
+++ b/frontend/src/lib/coach-api.js
@@ -1,0 +1,97 @@
+// Talking to the Coach endpoints, and knowing when to stop.
+//
+// Jobs are minutes-scale, so the client polls. The one rule worth stating: polling only runs
+// while a Coach surface is on screen or a job is known to be in flight. An app that pings the
+// server every thirty seconds forever because a feature exists is an app that costs battery
+// for a feature nobody is using.
+
+import { useEffect, useState, useCallback, useRef } from 'react'
+import { api } from './api.js'
+import { DEMO } from './demo.js'
+import { useStore } from '../store/useStore.js'
+
+const POLL_MS = 3000        // a job is running: often enough to feel live
+const IDLE_MS = 60000       // a Coach screen is open but nothing is running
+
+// The demo build has no backend, so it answers these locally with a canned proposal built
+// from its own seeded profile (lib/coach-demo.js). Everything downstream — validation,
+// staleness, apply, revert, the log — runs unchanged; only the provider is faked. The module
+// is imported dynamically so none of it lands in a self-hosted bundle.
+let demoMod = null
+const demo = async () => (demoMod = demoMod || await import('./coach-demo.js'))
+const S = () => useStore.getState().S
+
+export const coachStatus = async () => DEMO ? (await demo()).demoStatus() : api('/api/coach/status')
+export const requestReview = async note => DEMO ? (await demo()).demoReview(S()) : api('/api/coach/review', { method: 'POST', body: JSON.stringify({ note: note || '' }) })
+export const requestPlan = async intake => DEMO ? (await demo()).demoPlan(S(), intake) : api('/api/coach/plan', { method: 'POST', body: JSON.stringify({ intake }) })
+export const refinePlan = async text => DEMO ? (await demo()).demoRefine(S()) : api('/api/coach/plan', { method: 'POST', body: JSON.stringify({ refine: text }) })
+export const resolvePending = async body => DEMO ? (await demo()).demoResolve() : api('/api/coach/pending/resolve', { method: 'POST', body: JSON.stringify(body) })
+export const forgetCoach = async () => DEMO ? (await demo()).demoResolve() : api('/api/coach/forget', { method: 'POST', body: '{}' })
+export const disclosure = async () => DEMO ? (await demo()).demoDisclosure() : api('/api/coach/disclosure')
+
+/* Whose provider account this profile is about to spend. Its own call because the constraint is
+   that the Coach screen states it too, not just the admin card — and because in instance mode a
+   second profile is refused outright, which is something the user has to be able to read before
+   they ask for anything rather than after a job is turned down. */
+export const coachAccount = async () =>
+  DEMO ? { mode: 'instance', provider: 'demo', providerLabel: 'Demo', account: null, connected: true, reason: null, message: null }
+    : api('/api/coach/account')
+
+/* Admin-only. The token is write-only from the client's side: it goes up once and is never
+   read back, so there is deliberately no "show me the current credential" call to pair with it. */
+export const connectCredential = body => api('/api/admin/coach/connect', { method: 'POST', body: JSON.stringify(body) })
+export const disconnectCredential = () => api('/api/admin/coach/disconnect', { method: 'POST', body: '{}' })
+
+/**
+ * Live job/proposal state.
+ *
+ * `active` lets a caller (the Home card) subscribe only while it is mounted and visible;
+ * everything else keeps the poll off. Errors are swallowed on purpose — a Coach status call
+ * failing while you are mid-workout is not something to interrupt anyone about.
+ */
+export function useCoachStatus(active = true) {
+  const [state, setState] = useState({ job: null, pending: null, cap: null, loading: true })
+  const timer = useRef(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const s = await coachStatus()
+      setState({ ...s, loading: false })
+      return s
+    } catch {
+      setState(s => ({ ...s, loading: false }))
+      return null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!active) return
+    let stopped = false
+    const tick = async () => {
+      const s = await refresh()
+      if (stopped) return
+      timer.current = setTimeout(tick, s?.job ? POLL_MS : IDLE_MS)
+    }
+    tick()
+    return () => { stopped = true; clearTimeout(timer.current) }
+  }, [active, refresh])
+
+  return { ...state, refresh }
+}
+
+// Server failure classes, in the app's voice. The provider's own words go to the admin card;
+// what a lifter needs is what it means for them and whether trying again will help.
+export const JOB_ERRORS = {
+  off: 'The Coach isn’t set up on this instance.',
+  busy: 'The Coach is already thinking about your training.',
+  cap: 'The Coach is resting — try again tomorrow.',
+  consent: 'The Coach needs your go-ahead first.',
+  timeout: 'The Coach took too long and gave up.',
+  auth: 'The Coach couldn’t sign in to its provider — the instance owner needs to check its setup.',
+  missing: 'The Coach isn’t installed properly on this instance.',
+  provider: 'The Coach couldn’t run — the instance owner needs to check its setup.',
+  unusable: 'The Coach answered with something the app couldn’t use.',
+  restart: 'The server restarted while the Coach was thinking.',
+  nostate: 'The Coach couldn’t read your training data.',
+  internal: 'Something went wrong on the server.'
+}

--- a/frontend/src/lib/coach-demo.js
+++ b/frontend/src/lib/coach-demo.js
@@ -1,0 +1,132 @@
+// The Coach, in the demo build.
+//
+// The GitHub Pages demo has no backend at all, so there is nothing to run a CLI and nothing
+// to poll. Rather than hide the feature there — it is the most interesting thing the app
+// does — the demo answers the same calls locally with a canned proposal.
+//
+// It is built from the demo profile's actual routines rather than hard-coded, so every id
+// resolves, the before/after values are real, and applying it exercises exactly the same
+// code path as a live instance: validate, snapshot, apply, log, revert. What is faked is the
+// provider, not the feature.
+//
+// Nothing here ships in a self-hosted bundle: every entry point is behind DEMO, which Vite
+// replaces at build time.
+
+import { EXIDX, EXDB } from './exercises.js'
+import { modeOf } from './history.js'
+import { planHash } from './coach.js'
+import { t } from './i18n.js'
+
+const DELAY = 2200      // long enough to see "the Coach is thinking…", short enough to forgive
+
+let pending = null
+let job = null
+let timer = null
+
+const iso = d => d.toISOString().slice(0, 10)
+
+/** A change-set that reads like a real one, aimed at whatever the demo profile actually has. */
+function buildReview(S) {
+  const routine = (S.routines || []).find(r => (r.ex || []).length >= 2)
+  if (!routine) return null
+  const reps = (routine.ex || []).filter(e => modeOf(e) === 'reps')
+  const first = reps[0] || routine.ex[0]
+  const second = reps[1] || routine.ex[1]
+  const other = (S.routines || []).find(r => r.id !== routine.id)
+
+  // Something plausible that is *not* in this routine, from the same body part as the first
+  // exercise — a swap the reader can believe rather than a random pick out of 1,324.
+  const bp = EXIDX[first.id]?.bp
+  const swapTo = EXDB.find(e => e.bp === bp && e.eq === 'dumbbell' && !(routine.ex || []).some(x => x.id === e.id))
+    || EXDB.find(e => e.bp === bp && !(routine.ex || []).some(x => x.id === e.id))
+
+  const sessions = (S.workouts || []).slice(-9)
+  const changes = []
+  if (swapTo) changes.push({
+    id: 'd1', type: 'swap-exercise', target: { routineId: routine.id, exId: first.id },
+    before: EXIDX[first.id]?.n || first.id, after: { id: swapTo.id, name: swapTo.n },
+    why: t('Every top set on this one came in at RPE 9.5 or above for three sessions and the weight has not moved. Swapping the movement for four weeks usually breaks that stall faster than grinding the same one.')
+  })
+  if (second) changes.push({
+    id: 'd2', type: 'sets', target: { routineId: routine.id, exId: second.id },
+    before: second.sets ?? 3, after: Math.max(1, (second.sets ?? 3) - 1),
+    why: t('Sessions have been running about fifteen minutes over. This is the accessory with the least to lose from one set fewer.')
+  })
+  if (other) changes.push({
+    id: 'd3', type: 'week', target: { weekday: 6 }, before: null, after: other.id,
+    why: t('You have moved this session to Saturday three weeks running. Better the plan says so than that you keep overriding it.')
+  })
+
+  return {
+    id: 'demo-review', kind: 'review', createdAt: Date.now(), expiresAt: Date.now() + 864e5,
+    planHash: planHash(S), iteration: 1,
+    summary: t('Three things worth changing, and one worth knowing about. Everything else is working — the squat and the pulls are both progressing on schedule.'),
+    evidence: { from: sessions[0]?.d || iso(new Date(Date.now() - 28 * 864e5)), to: sessions.at(-1)?.d || iso(new Date()), sessions: sessions.length || 9 },
+    changes,
+    notes: [t('Body weight has been flat for four weeks while the goal is to gain. That is a kitchen problem rather than a training one — the plan is not what is holding it back.')]
+  }
+}
+
+/** A small, honest starter plan for the demo's creation flow. */
+function buildPlan(S, intake) {
+  const pick = (bp, eq) => EXDB.find(e => e.bp === bp && (!eq || e.eq === eq)) || EXDB.find(e => e.bp === bp)
+  const days = intake?.preferredDays?.length ? intake.preferredDays.slice(0, 3) : [1, 3, 5]
+  const eq = (intake?.equipment || [])[0] || null
+  const mk = (id, name, sets, reps, why) => ({ id, sets, reps, mode: 'reps', why })
+  const routines = [
+    {
+      id: 'dr1', name: t('Full body A'), emoji: '💪', prog: 'linear',
+      why: t('The two big lower-body and pressing patterns first, while you are fresh.'),
+      ex: [
+        mk(pick('upper legs', eq)?.id, null, 3, 8, t('The main lower-body driver — where most of the strength comes from.')),
+        mk(pick('chest', eq)?.id, null, 3, 10, t('Horizontal pressing, the other half of the session.')),
+        mk(pick('back', eq)?.id, null, 3, 10, t('A pull for every press, so the shoulders stay balanced.'))
+      ].filter(e => e.id)
+    },
+    {
+      id: 'dr2', name: t('Full body B'), emoji: '🏋️', prog: 'linear',
+      why: t('The same patterns, different variations — enough overlap to progress, enough difference to stay fresh.'),
+      ex: [
+        mk(pick('upper legs', eq)?.id, null, 3, 10, t('Same pattern, higher reps than day A.')),
+        mk(pick('shoulders', eq)?.id, null, 3, 10, t('Vertical pressing.')),
+        mk(pick('upper arms', eq)?.id, null, 3, 12, t('Direct arm work, since you asked for it.'))
+      ].filter(e => e.id)
+    }
+  ]
+  const week = {}
+  days.forEach((d, i) => { week[d] = routines[i % routines.length].id })
+  return {
+    id: 'demo-plan', kind: 'create', createdAt: Date.now(), expiresAt: Date.now() + 864e5, iteration: 1,
+    planHash: planHash(S),
+    summary: t('A two-day rotation across three sessions a week, built around the equipment you listed. Compounds first, one pull for every press, and enough overlap between the days that nothing goes two weeks without being trained.'),
+    bundle: {
+      opengym_plan: 1, name: t('Coach plan'),
+      summary: t('A two-day rotation across three sessions a week, built around the equipment you listed. Compounds first, one pull for every press, and enough overlap between the days that nothing goes two weeks without being trained.'),
+      basedOn: (S.workouts || []).length ? t('Based on the training already in this demo profile.') : t('No training history yet — starting conservatively.'),
+      week, routines, customEx: []
+    }
+  }
+}
+
+/* ---------------- the API surface the demo stands in for ---------------- */
+
+export const demoStatus = () => ({ job, pending, cap: { used: 0, limit: 0 } })
+
+function start(kind, make) {
+  if (job) throw Object.assign(new Error(t('The Coach is already thinking about your training.')), { status: 409 })
+  job = { id: 'demo-' + kind, kind, state: 'running', startedAt: Date.now() }
+  clearTimeout(timer)
+  timer = setTimeout(() => { pending = make(); job = null }, DELAY)
+  return { job }
+}
+export const demoReview = S => start('review', () => buildReview(S))
+export const demoPlan = (S, intake) => start('create', () => buildPlan(S, intake))
+export const demoRefine = S => start('create', () => {
+  const p = buildPlan(S, null)
+  return { ...p, iteration: (pending?.iteration || 1) + 1, summary: t('Revised as you asked. Everything you did not question is exactly as it was.') + ' ' + p.summary }
+})
+export const demoResolve = () => { pending = null; return { ok: true } }
+export const demoDisclosure = () => ({
+  provider: 'demo', providerLabel: t('the configured AI provider'),
+  categories: ['plan', 'training', 'bodyweight', 'profile', 'prefs'], version: 1
+})

--- a/frontend/src/views/Admin.jsx
+++ b/frontend/src/views/Admin.jsx
@@ -8,6 +8,7 @@ import { workoutVolume, setsDone } from '../lib/history.js'
 import { confirmSheet } from '../sheets.jsx'
 import Icon from '../components/Icon.jsx'
 import { Button } from '../components/ui.jsx'
+import AdminCoach from './AdminCoach.jsx'
 
 // Admin-only operator dashboard (owner passkey + admin flag; guarded again server-side).
 // Deliberately English-only — it isn't part of the translated end-user surface, so it stays
@@ -131,6 +132,10 @@ export default function Admin() {
         <span className="tag acc">{dur(Date.now() - u.live.startedAt)}</span>
       </div>)}
     </div>}
+
+    {/* Renders nothing at all unless the instance offers the Coach, so an admin page on a
+        box that never enabled it is byte-for-byte the page it was before. */}
+    <AdminCoach />
 
     <InvitesCard invites={invites} reload={loadInvites} />
 

--- a/frontend/src/views/AdminCoach.jsx
+++ b/frontend/src/views/AdminCoach.jsx
@@ -1,0 +1,244 @@
+import { useEffect, useState } from 'react'
+import { useUI } from '../store/useUI.js'
+import { api } from '../lib/api.js'
+import Icon from '../components/Icon.jsx'
+import { Button, Switch, TextField } from '../components/ui.jsx'
+
+/* The operator's side of the Coach: is it on, can it reach a model, and what has it been
+   doing. Like the rest of the admin dashboard this is deliberately English-only — it isn't
+   part of the translated end-user surface.
+ *
+ * What it never shows: anybody's intake answers, payloads or proposals. An admin can enable
+ * the feature and see that jobs ran; they cannot read what their users asked it. */
+
+const rel = ts => {
+  if (!ts) return 'never'
+  const s = Math.max(0, (Date.now() - new Date(ts).getTime()) / 1000)
+  if (s < 60) return 'just now'
+  if (s < 3600) return Math.floor(s / 60) + 'm ago'
+  if (s < 86400) return Math.floor(s / 3600) + 'h ago'
+  return Math.floor(s / 86400) + 'd ago'
+}
+
+export default function AdminCoach() {
+  const toast = useUI(s => s.toast)
+  const openSheet = useUI(s => s.openSheet)
+  const [d, setD] = useState(null)
+  const [busy, setBusy] = useState(false)
+
+  const load = () => api('/api/admin/coach').then(setD).catch(e => toast(e.message || 'Failed to load'))
+  useEffect(() => { load() }, [])
+
+  const patch = async body => {
+    setBusy(true)
+    try { await api('/api/admin/coach/config', { method: 'POST', body: JSON.stringify(body) }); await load() }
+    catch (e) { toast(e.message) }
+    setBusy(false)
+  }
+  const test = async () => {
+    setBusy(true)
+    try {
+      const r = await api('/api/admin/coach/test', { method: 'POST', body: '{}' })
+      toast(r.ok ? 'Coach test passed ✅' : 'Test failed: ' + (r.error || 'unknown'))
+      await load()
+    } catch (e) { toast(e.message) }
+    setBusy(false)
+  }
+  const disconnect = async () => {
+    setBusy(true)
+    try { await api('/api/admin/coach/disconnect', { method: 'POST', body: '{}' }); toast('Disconnected'); await load() }
+    catch (e) { toast(e.message) }
+    setBusy(false)
+  }
+
+  if (!d) return <div className="card"><div className="muted small">Loading Coach status…</div></div>
+
+  if (d.disabledByEnv) return <div className="card">
+    <h2 style={{ margin: '0 0 6px' }}>AI Coach</h2>
+    <div className="muted small">Force-disabled by <code>COACH_DISABLED</code> in the environment. Remove it to configure the Coach here.</div>
+  </div>
+
+  const meta = d.providers.find(p => p.id === d.provider) || {}
+  const authed = d.auth?.state === 'connected' || d.auth?.state === 'not-required'
+  const live = d.enabled && d.runtime.ok && authed
+
+  return <div className="card" style={{ borderColor: live ? 'var(--acc)' : undefined }}>
+    <div className="row between" style={{ marginBottom: 8 }}>
+      <h2 style={{ margin: 0 }}>AI Coach</h2>
+      <Switch checked={!!d.enabled} disabled={busy} onChange={v => patch({ enabled: v })} />
+    </div>
+
+    {!d.enabled && <div className="muted small">Off. Users see no Coach anywhere in the app.</div>}
+
+    {d.enabled && <>
+      <div className="tiles" style={{ textAlign: 'left', marginBottom: 10 }}>
+        <div className="tile"><div className="l">Runtime</div>
+          <div className="v" style={{ fontSize: '.9rem', color: d.runtime.ok ? 'var(--green)' : 'var(--red)' }}>{d.runtime.ok ? 'ready' : 'missing'}</div></div>
+        <div className="tile"><div className="l">Credential</div>
+          <div className="v" style={{ fontSize: '.9rem', color: authed ? 'var(--green)' : 'var(--red)' }}>{authLabel(d.auth)}</div></div>
+        <div className="tile"><div className="l">Jobs today</div><div className="v" style={{ fontSize: '1.1rem' }}>{d.jobsToday}</div></div>
+        <div className="tile"><div className="l">Last run</div><div className="v" style={{ fontSize: '.85rem' }}>{rel(d.lastSuccess?.at)}</div></div>
+      </div>
+
+      {d.runtime.version && <div className="dim small" style={{ marginBottom: 8 }}>{meta.runtime || meta.label} · {d.runtime.version}</div>}
+      {!d.runtime.ok && d.runtime.error && <div className="small" style={{ color: 'var(--red)', marginBottom: 8 }}>{d.runtime.error}</div>}
+
+      {/* The privilege drop, stated plainly. It fails closed, so when this reads no, nothing
+          runs at all — and the admin needs to learn that here rather than from a user
+          reporting that the Coach does nothing. The reason is the server's own words. */}
+      {d.unprivileged && !d.unprivileged.ok &&
+        <div className="small" style={{ color: 'var(--red)', marginBottom: 8, lineHeight: 1.5 }}>
+          Jobs are disabled: {d.unprivileged.why}. No job will run until this is fixed.
+        </div>}
+      {d.unprivileged?.ok &&
+        <div className="dim small" style={{ marginBottom: 8 }}>
+          Jobs run unprivileged: {d.unprivileged.dropped ? 'yes' : 'no — this host has no separate user to drop to'}
+        </div>}
+
+      {/* Whose account is being spent, in the admin's own view. The same fact the user sees on
+          their Coach screen, because "the admin card and the user screen must both name the
+          account" is only true if neither is inferring it from settings. */}
+      <div className="dim small" style={{ marginBottom: 8 }}>
+        {d.authMode === 'profile'
+          ? 'Each profile signs in with their own account.'
+          : d.boundUid
+            ? 'One shared account, already in use by a profile. Any other profile is refused.'
+            : 'One shared account. The first profile to use it binds it; every other profile is then refused.'}
+      </div>
+
+      {/* provider */}
+      <h4 className="sec" style={{ marginTop: 4 }}>Provider</h4>
+      <div className="row" style={{ flexWrap: 'wrap', gap: 7, marginBottom: 10 }}>
+        {d.providers.map(p => <button key={p.id} className={'chip' + (p.id === d.provider ? ' on' : '')}
+          disabled={busy} onClick={() => patch({ provider: p.id })}>{p.label}</button>)}
+      </div>
+
+      {/* credential */}
+      {(meta.setupToken || meta.apiKey) && <>
+        <h4 className="sec">Credential</h4>
+        {d.auth?.state === 'connected' ? <>
+          <div className="small muted" style={{ marginBottom: 8 }}>
+            Connected{d.auth.account ? ' as ' + d.auth.account : ''} via {credentialLabel(d.auth.type)} · {rel(d.auth.connectedAt)}
+          </div>
+          <div className="row" style={{ gap: 8 }}>
+            <Button size="sm" icon="check" disabled={busy} onClick={test}>Test the Coach</Button>
+            <Button size="sm" danger disabled={busy} onClick={disconnect}>Disconnect</Button>
+          </div>
+        </> : <>
+          {d.auth?.state === 'expired' && <div className="small" style={{ color: 'var(--red)', marginBottom: 8 }}>The stored credential expired — connect again.</div>}
+          {d.auth?.state === 'replace-required' && <div className="small" style={{ color: 'var(--red)', marginBottom: 8 }}>
+            The old Claude credential is no longer used. Add a Claude Code setup token instead.
+          </div>}
+          {d.auth?.state === 'unreadable' && <div className="small" style={{ color: 'var(--red)', marginBottom: 8 }}>
+            The stored credential can't be decrypted — this usually means ./data was restored without its <code>secret</code> file. Connect again.
+          </div>}
+          <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+            {meta.setupToken && <Button size="sm" variant="primary" icon="key" disabled={busy}
+              onClick={() => openSheet(close => <SetupTokenSheet close={close} onDone={load} label={meta.label} />)}>Add CLI token</Button>}
+            {meta.apiKey && !meta.setupToken && <Button size="sm" icon="lock" disabled={busy}
+              onClick={() => openSheet(close => <ApiKeySheet close={close} onDone={load} label={meta.label} />)}>Use an API key</Button>}
+          </div>
+        </>}
+      </>}
+
+      {/* limits */}
+      <h4 className="sec">Limits</h4>
+      <div className="row" style={{ gap: 10, flexWrap: 'wrap', marginBottom: 4 }}>
+        <label className="small muted">Per user / day
+          <input className="num" type="number" min="0" max="200" defaultValue={d.caps.perProfileDaily} style={{ width: 70, marginLeft: 8 }}
+            onBlur={e => patch({ caps: { ...d.caps, perProfileDaily: +e.target.value } })} /></label>
+        <label className="small muted">Whole instance / day
+          <input className="num" type="number" min="0" max="5000" defaultValue={d.caps.instanceDaily} style={{ width: 70, marginLeft: 8 }}
+            onBlur={e => patch({ caps: { ...d.caps, instanceDaily: +e.target.value } })} /></label>
+      </div>
+      <div className="dim small" style={{ marginBottom: 10 }}>0 = no limit. Every job is one session on your provider account.</div>
+
+      <h4 className="sec">Model</h4>
+      <TextField defaultValue={d.model || ''} placeholder="(the provider default)"
+        onBlur={e => e.target.value !== (d.model || '') && patch({ model: e.target.value })} />
+
+      {d.lastError && <>
+        <h4 className="sec">Last failure</h4>
+        <div className="small" style={{ color: 'var(--red)' }}>{d.lastError.errorClass}{d.lastError.detail ? ' — ' + d.lastError.detail : ''}</div>
+        <div className="dim" style={{ fontSize: '.72rem' }}>{rel(d.lastError.at)}</div>
+      </>}
+
+      {!!d.recent?.length && <>
+        <h4 className="sec">Recent jobs</h4>
+        {d.recent.slice(0, 8).map((e, i) => <div key={i} className="row between" style={{ padding: '5px 2px', borderBottom: '1px solid var(--sep)' }}>
+          <span className="small">{e.kind}{e.trigger === 'scheduled' ? ' · scheduled' : ''}</span>
+          <span className="dim" style={{ fontSize: '.72rem' }}>
+            <span style={{ color: e.outcome === 'failed' ? 'var(--red)' : e.outcome === 'ready' ? 'var(--acc)' : undefined }}>{e.outcome}</span>
+            {e.ms ? ' · ' + Math.round(e.ms / 1000) + 's' : ''} · {rel(e.at)}
+          </span>
+        </div>)}
+      </>}
+    </>}
+  </div>
+}
+
+const authLabel = a => ({
+  connected: 'connected', 'not-required': 'n/a', disconnected: 'needed', expired: 'expired', unreadable: 'unreadable', 'replace-required': 'replace'
+}[a?.state] || '—')
+
+const credentialLabel = type => ({
+  'cli-token': 'Claude Code setup token', 'chatgpt-cli': 'ChatGPT CLI login', oauth: 'legacy token', apikey: 'API key'
+}[type] || 'credential')
+
+/* ------------------------------- setup token -------------------------------- */
+
+function SetupTokenSheet({ close, onDone, label }) {
+  const toast = useUI(s => s.toast)
+  const [token, setToken] = useState('')
+  // Which account this token belongs to. Optional, and stored as a plain label — it is what the
+  // admin card and the user's Coach screen both show when they name whose account is spent.
+  const [account, setAccount] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const save = async () => {
+    setBusy(true)
+    try {
+      const r = await api('/api/admin/coach/connect', { method: 'POST', body: JSON.stringify({ type: 'cli-token', token: token.trim(), account: account.trim() }) })
+      setToken('')
+      toast(r.test?.ok ? 'Connected ✅' : 'Saved, but the test failed: ' + (r.test?.error || ''))
+      close(); onDone()
+    } catch (e) { toast(e.message); setBusy(false) }
+  }
+
+  return <>
+    <h3>Connect {label}</h3>
+    <div className="muted small" style={{ lineHeight: 1.5, marginBottom: 12 }}>
+      On a trusted computer where you use Claude Code, run <code>claude setup-token</code>, complete its normal browser sign-in, then paste the token it prints here. This app never opens or handles Claude's authorization flow.
+    </div>
+    <TextField value={token} autoFocus type="password" placeholder="paste setup token" onChange={e => setToken(e.target.value)} />
+    <div style={{ height: 8 }} />
+    <TextField value={account} placeholder="whose account is this? (e.g. you@example.com)" onChange={e => setAccount(e.target.value)} />
+    <div style={{ height: 12 }} />
+    <Button variant="primary" disabled={busy || !token.trim()} onClick={save}>Save and test</Button>
+    <div style={{ height: 8 }} />
+  </>
+}
+
+function ApiKeySheet({ close, onDone, label }) {
+  const toast = useUI(s => s.toast)
+  const [key, setKey] = useState('')
+  const [busy, setBusy] = useState(false)
+  const save = async () => {
+    setBusy(true)
+    try {
+      const r = await api('/api/admin/coach/connect', { method: 'POST', body: JSON.stringify({ type: 'apikey', token: key.trim() }) })
+      toast(r.test?.ok ? 'Key saved ✅' : 'Saved, but the test failed: ' + (r.test?.error || ''))
+      close(); onDone()
+    } catch (e) { toast(e.message); setBusy(false) }
+  }
+  return <>
+    <h3>{label} API key</h3>
+    <div className="muted small" style={{ lineHeight: 1.5, marginBottom: 12 }}>
+      Stored encrypted on this server and passed to the provider runtime only while a job runs. It is never shown again and never leaves the server.
+    </div>
+    <TextField value={key} autoFocus type="password" placeholder="sk-…" onChange={e => setKey(e.target.value)} />
+    <div style={{ height: 12 }} />
+    <Button variant="primary" disabled={busy || !key.trim()} onClick={save}>Save key</Button>
+    <div style={{ height: 8 }} />
+  </>
+}

--- a/frontend/src/views/Coach.jsx
+++ b/frontend/src/views/Coach.jsx
@@ -1,0 +1,314 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useStore, DEF } from '../store/useStore.js'
+import { useUI } from '../store/useUI.js'
+import { t } from '../lib/i18n.js'
+import { fmtDate } from '../lib/format.js'
+import { DEMO } from '../lib/demo.js'
+import { MOBILE } from '../lib/mobile.js'
+import {
+  coachAvailable, hasConsent, CONSENT_VERSION, emptyCoach,
+  canRevert, revertLast, changeTitle, recordDismissal
+} from '../lib/coach.js'
+import {
+  useCoachStatus, requestReview, resolvePending, forgetCoach, disclosure, JOB_ERRORS
+} from '../lib/coach-api.js'
+import { confirmSheet } from '../sheets.jsx'
+import Icon from '../components/Icon.jsx'
+import { Section, Row, Button, TextArea, Switch, SelectRow } from '../components/ui.jsx'
+
+/* The Coach's home: what it's doing, what it's proposing, what it has done before, and every
+   switch that turns it off. Deliberately one screen — a feature that edits your training plan
+   should not scatter its controls, least of all the ones that stop it. */
+
+const GOALS = ['strength', 'muscle', 'general fitness', 'fat loss', 'endurance']
+
+// Rendered from the same list the server builds payloads from (GET /api/coach/disclosure),
+// so the promise on screen cannot drift from what actually leaves the box.
+const CATEGORY_TEXT = {
+  plan: ['Your plan', 'Routines, exercises, sets and reps, your weekly schedule and progression settings.'],
+  training: ['Your logged training', 'Sets you logged in the review window — weights, reps, times, effort ratings and how long sessions took.'],
+  bodyweight: ['Body weight', 'Weigh-ins from the same window, and your goal weight if you set one.'],
+  profile: ['What you tell the Coach', 'Your intake answers, including any limitations or injuries you describe.'],
+  prefs: ['A few preferences', 'Your unit, your language and which effort scale you log.']
+}
+
+export default function Coach() {
+  const nav = useNavigate()
+  const S = useStore(s => s.S)
+  const user = useStore(s => s.user)
+  const config = useStore(s => s.config)
+  const update = useStore(s => s.update)
+  const toast = useUI(s => s.toast)
+  const [note, setNote] = useState('')
+  const [busy, setBusy] = useState(false)
+  const { job, pending, cap, refresh } = useCoachStatus(true)
+
+  // Gating lives in one predicate; if the instance isn't offering the Coach this route simply
+  // isn't a place you can be.
+  useEffect(() => { if (!coachAvailable(config, user, { demo: DEMO, mobile: MOBILE })) nav('/home', { replace: true }) }, [config, user])
+  if (!coachAvailable(config, user, { demo: DEMO, mobile: MOBILE })) return null
+
+  const consented = hasConsent(S)
+  const coach = S.coach || emptyCoach()
+
+  const askReview = async () => {
+    setBusy(true)
+    try {
+      await requestReview(note)
+      setNote('')
+      toast(t('The Coach is reading your training…'))
+      refresh()
+    } catch (e) { toast(e.message || t('Could not ask the Coach')) }
+    setBusy(false)
+  }
+
+  const turnOff = () => confirmSheet({
+    title: t('Turn the Coach off?'),
+    message: t('Any pending suggestion is discarded and scheduled reviews stop. Your Coach history stays, and you can turn it back on anytime.'),
+    confirmText: t('Turn off'), danger: true,
+    onConfirm: async () => {
+      try { await forgetCoach() } catch (e) { /* server-side copy goes on the next call */ }
+      update(s => { s.coach = { ...(s.coach || emptyCoach()), consent: null, cadence: 'off' } })
+      toast(t('The Coach is off'))
+      nav('/home')
+    }
+  })
+
+  const doRevert = () => confirmSheet({
+    title: t('Undo the last Coach changes?'),
+    message: t('Your plan goes back to how it was before you accepted them. Workouts you have logged since are untouched.'),
+    confirmText: t('Undo'),
+    onConfirm: () => {
+      let ok = false
+      update(s => { ok = revertLast(s) })
+      toast(ok ? t('Plan restored') : t('Nothing to undo'))
+    }
+  })
+
+  return <div className="narrow">
+    <div className="hdr">
+      <button className="iconbtn" onClick={() => nav('/plan')} aria-label={t('Back')}><Icon name="chevronLeft" /></button>
+      <div style={{ flex: 1, marginLeft: 10 }}>
+        <h1>{t('Coach')}</h1>
+        <div className="sub">{t('Plan design and reviews, from your own training')}</div>
+      </div>
+    </div>
+
+    {!consented
+      ? <ConsentCard onDone={() => refresh()} />
+      : <>
+        <StatusCard job={job} pending={pending} nav={nav} />
+
+        {!job && !pending && <div className="card">
+          <h2 style={{ margin: '0 0 6px' }}>{t('Ask for a review')}</h2>
+          <div className="muted small" style={{ marginBottom: 10 }}>
+            {t('The Coach reads what you have actually logged since its last look and suggests changes to your plan — each one with its reason.')}
+          </div>
+          <TextArea rows={2} value={note} maxLength={1000} onChange={e => setNote(e.target.value)}
+            placeholder={t('Anything it should know? (optional) — e.g. “right shoulder pinches on overhead work”')} />
+          <div style={{ height: 10 }} />
+          <Button variant="primary" icon="sparkles" disabled={busy} onClick={askReview}>{t('Ask for a review')}</Button>
+          {cap?.limit > 0 && <div className="dim small" style={{ marginTop: 8, textAlign: 'center' }}>
+            {t('{0} of {1} Coach runs used today', cap.used, cap.limit)}
+          </div>}
+        </div>}
+
+        {!S.routines.length && <div className="card">
+          <div className="muted small" style={{ marginBottom: 10 }}>{t('No plan yet — the Coach can build you one from a few questions.')}</div>
+          <Button variant="primary" icon="sparkles" onClick={() => nav('/coach/intake')}>{t('Let the Coach build my plan')}</Button>
+        </div>}
+
+        <CadenceCard coach={coach} update={update} />
+
+        <Section title={t('Coach profile')} footer={t('Used by every proposal — keep limitations here up to date.')}>
+          <Row icon="clipboard" iconTint="var(--indigo)" title={t('Your answers')}
+            subtitle={coach.profile ? summarise(coach.profile) : t('Not set yet')}
+            accessory="chevron" onClick={() => nav('/coach/intake?edit=1')} />
+        </Section>
+
+        <LogCard coach={coach} />
+
+        <Section title={t('Controls')}>
+          {canRevert(S) && <Row icon="reset" iconTint="var(--blue)" title={t('Undo the last Coach changes')} accessory="chevron" onClick={doRevert} />}
+          <Row icon="signOut" iconTint="var(--red)" title={t('Turn the Coach off')} danger onClick={turnOff} />
+        </Section>
+      </>}
+  </div>
+}
+
+const summarise = p => [
+  p.goal && t(p.goal),
+  p.daysPerWeek && t('{0} days a week', p.daysPerWeek),
+  p.sessionMin && t('{0} min', p.sessionMin)
+].filter(Boolean).join(' · ')
+
+/* ---------------------------------- consent ---------------------------------- */
+
+function ConsentCard({ onDone }) {
+  const update = useStore(s => s.update)
+  const config = useStore(s => s.config)
+  const toast = useUI(s => s.toast)
+  const openSheet = useUI(s => s.openSheet)
+  const [info, setInfo] = useState(null)
+  useEffect(() => { disclosure().then(setInfo).catch(() => {}) }, [])
+
+  const agree = () => {
+    update(s => { s.coach = { ...(s.coach || emptyCoach()), consent: { agreedAt: new Date().toISOString(), version: CONSENT_VERSION } } })
+    toast(t('The Coach is on'))
+    onDone()
+  }
+
+  const open = () => openSheet(close => <>
+    <h3>{t('Before the Coach starts')}</h3>
+    <div className="muted small" style={{ lineHeight: 1.5, marginBottom: 12 }}>
+      {t('When you ask for a plan or a review, this instance sends the following to {0}, running on this server under the instance owner’s account.',
+        info?.providerLabel || config?.coach?.providerLabel || t('the configured AI provider'))}
+    </div>
+    <div className="sect-b">
+      {(info?.categories || Object.keys(CATEGORY_TEXT)).map(k => {
+        const [title, sub] = CATEGORY_TEXT[k] || [k, '']
+        return <div key={k} className="lrow">
+          <span className="lrow-i" style={{ '--tint': 'var(--acc)' }}><Icon name="check" /></span>
+          <span className="lrow-m"><span className="lrow-t">{t(title)}</span><span className="lrow-s">{t(sub)}</span></span>
+        </div>
+      })}
+    </div>
+    <div className="dim small" style={{ lineHeight: 1.5, display: 'grid', gap: 8, marginTop: 12 }}>
+      <div>{t('Your name, your sign-in details and everything else about your account stay here. Other people’s data is never included.')}</div>
+      <div>{t('Nothing the Coach suggests is applied on its own — you review every change and can undo it afterwards.')}</div>
+      <div>{t('You can turn this off at any time, which also discards anything the Coach is holding for you.')}</div>
+      <div style={{ color: 'var(--yellow)' }}>{t('The Coach is not a doctor or a physiotherapist. If something hurts, ask a professional.')}</div>
+    </div>
+    <div style={{ height: 14 }} />
+    <Button variant="primary" onClick={() => { close(); agree() }}>{t('I understand — turn the Coach on')}</Button>
+    <div style={{ height: 8 }} />
+    <Button onClick={close}>{t('Not now')}</Button>
+  </>)
+
+  return <div className="card">
+    <div className="row" style={{ gap: 10, marginBottom: 6 }}>
+      <span className="lrow-i" style={{ '--tint': 'var(--acc)' }}><Icon name="sparkles" /></span>
+      <div className="big" style={{ fontSize: 20 }}>{t('Meet the Coach')}</div>
+    </div>
+    <div className="muted small" style={{ marginBottom: 12, lineHeight: 1.5 }}>
+      {t('An AI coach that can design your plan and adjust it from what you actually log. It runs on this server, it never changes anything without your say-so, and it is off until you turn it on.')}
+    </div>
+    <Button variant="primary" icon="sparkles" onClick={open}>{t('See what it would use')}</Button>
+  </div>
+}
+
+/* ---------------------------------- status ---------------------------------- */
+
+function StatusCard({ job, pending, nav }) {
+  if (job) return <div className="card">
+    <div className="row" style={{ gap: 10 }}>
+      <span className="lrow-i" style={{ background: 'var(--orange)' }}><Icon name="sparkles" /></span>
+      <div>
+        <div style={{ fontWeight: 600 }}>{t('The Coach is thinking…')}</div>
+        <div className="muted small">{t('This takes a minute or two. You can leave this screen — it keeps going.')}</div>
+      </div>
+    </div>
+  </div>
+
+  if (pending) return <div className="card" style={{ borderColor: 'var(--acc)' }}>
+    <div className="today-row" onClick={() => nav('/coach/proposal')}>
+      <div className="row" style={{ gap: 9, minWidth: 0 }}>
+        <span className="lrow-i" style={{ background: 'var(--acc)' }}><Icon name="clipboard" /></span>
+        <div style={{ minWidth: 0 }}>
+          <div className="lbl2">{pending.kind === 'create' ? t('Your plan is ready') : t('Suggestions ready')}</div>
+          <div className="ttl">{pending.kind === 'create'
+            ? t('{0} routines to look over', pending.bundle?.routines?.length || 0)
+            : t(pending.changes?.length === 1 ? '{0} suggestion' : '{0} suggestions', pending.changes?.length || 0)}</div>
+        </div>
+      </div>
+      <span className="tag acc">{t('Review')}</span>
+    </div>
+  </div>
+
+  return null
+}
+
+/* ---------------------------------- cadence ---------------------------------- */
+
+function CadenceCard({ coach, update }) {
+  const cadence = coach.cadence && coach.cadence !== 'off' ? coach.cadence : null
+  const mode = !cadence ? 'off' : cadence.weekly ? 'weekly' : 'every'
+  const setMode = m => update(s => {
+    const c = (s.coach = s.coach || emptyCoach())
+    c.cadence = m === 'off' ? 'off' : m === 'weekly' ? { weekly: { day: 0, time: '18:00' } } : { everyWorkouts: 4 }
+  })
+  const patch = fn => update(s => { const c = (s.coach = s.coach || emptyCoach()); fn(c) })
+
+  return <Section title={t('Automatic reviews')}
+    footer={mode === 'off'
+      ? t('Off — the Coach only looks when you ask it to.')
+      : t('You are only notified when the Coach actually has something to suggest.')}>
+    <SelectRow icon="clock" iconTint="var(--purple)" title={t('When')}
+      value={mode} onChange={setMode}
+      options={[
+        { value: 'off', label: t('Off') },
+        { value: 'weekly', label: t('Weekly'), subtitle: t('On a day and time you choose') },
+        { value: 'every', label: t('After every few workouts'), subtitle: t('As soon as you have logged enough') }
+      ]} />
+    {mode === 'weekly' && <>
+      <SelectRow icon="calendar" iconTint="var(--orange)" title={t('Day')}
+        value={cadence.weekly.day}
+        onChange={v => patch(c => { c.cadence = { weekly: { ...c.cadence.weekly, day: v } } })}
+        options={['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'].map((d, i) => ({ value: i, label: t(d) }))} />
+      <Row icon="clock" iconTint="var(--purple)" title={t('Time')}>
+        <input type="time" className="timef" value={cadence.weekly.time || '18:00'}
+          onChange={e => patch(c => { c.cadence = { weekly: { ...c.cadence.weekly, time: e.target.value } } })} />
+      </Row>
+    </>}
+    {mode === 'every' && <SelectRow icon="dumbbell" iconTint="var(--teal)" title={t('After how many workouts')}
+      value={cadence.everyWorkouts || 4}
+      onChange={v => patch(c => { c.cadence = { everyWorkouts: v } })}
+      options={[3, 4, 5, 6, 8, 10].map(n => ({ value: n, label: t('{0} workouts', n) }))} />}
+  </Section>
+}
+
+/* ---------------------------------- log ---------------------------------- */
+
+function LogCard({ coach }) {
+  const openSheet = useUI(s => s.openSheet)
+  const log = [...(coach.log || [])].reverse()
+  if (!log.length) return null
+
+  const detail = e => openSheet(close => <>
+    <h3>{e.kind === 'create' ? t('Plan from the Coach') : e.kind === 'revert' ? t('Undo') : t('Coach review')}</h3>
+    <div className="dim small" style={{ marginBottom: 10 }}>{fmtDate(new Date(e.at).toISOString().slice(0, 10), true)}</div>
+    {e.summary && <div className="muted small" style={{ lineHeight: 1.5, marginBottom: 12 }}>{e.summary}</div>}
+    {!!e.evidence?.sessions && <div className="dim small" style={{ marginBottom: 10 }}>
+      {t('Based on {0} sessions', e.evidence.sessions)}{e.evidence.from ? ' · ' + fmtDate(e.evidence.from) + ' – ' + fmtDate(e.evidence.to) : ''}
+    </div>}
+    {(e.decisions || []).map(d => <div key={d.id} className="row between" style={{ padding: '8px 2px', borderBottom: '1px solid var(--sep)', gap: 10 }}>
+      <div style={{ minWidth: 0 }}>
+        <div className="small" style={{ fontWeight: 600 }}>{changeTitle(d)}</div>
+        {d.why && <div className="dim" style={{ fontSize: '.72rem', lineHeight: 1.4 }}>{d.why}</div>}
+      </div>
+      <span className="tag" style={d.status === 'accepted' ? { color: 'var(--acc)' } : { color: 'var(--label-3)' }}>
+        {d.status === 'accepted' ? t('applied') : t('declined')}
+      </span>
+    </div>)}
+    {(e.notes || []).map((n, i) => <div key={i} className="muted small" style={{ marginTop: 10, lineHeight: 1.5 }}>💬 {n}</div>)}
+    <div style={{ height: 10 }} />
+  </>)
+
+  return <>
+    <h4 className="sec">{t('Coach history')}</h4>
+    <div className="list">
+      {log.slice(0, 20).map(e => {
+        const applied = (e.decisions || []).filter(d => d.status === 'accepted').length
+        return <div key={e.id} className="item" onClick={() => detail(e)}>
+          <div className="grow">
+            <div className="tt">{e.kind === 'create' ? t('Built a plan') : e.kind === 'revert' ? t('Undid the last changes') : t('Reviewed your training')}</div>
+            <div className="ss">{fmtDate(new Date(e.at).toISOString().slice(0, 10))}
+              {e.kind === 'review' ? ' · ' + t('{0} applied', applied) : ''}</div>
+          </div>
+          <Icon name="chevronRight" className="chev" />
+        </div>
+      })}
+    </div>
+  </>
+}

--- a/frontend/src/views/CoachIntake.jsx
+++ b/frontend/src/views/CoachIntake.jsx
@@ -1,0 +1,186 @@
+import { useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useStore } from '../store/useStore.js'
+import { useUI } from '../store/useUI.js'
+import { t } from '../lib/i18n.js'
+import { DAYN } from '../lib/format.js'
+import { EXDB } from '../lib/exercises.js'
+import { emptyCoach, coachAvailable } from '../lib/coach.js'
+import { requestPlan } from '../lib/coach-api.js'
+import { DEMO } from '../lib/demo.js'
+import { MOBILE } from '../lib/mobile.js'
+import Icon from '../components/Icon.jsx'
+import { Button, TextArea, Segmented } from '../components/ui.jsx'
+
+/* The intake: one topic per screen, because a single form with eleven fields is a form people
+   abandon. Only the first two questions are required — everything after them improves the
+   plan without gating it, and someone who wants to just get training should be able to. */
+
+const GOALS = [
+  ['strength', 'Get stronger'],
+  ['muscle', 'Build muscle'],
+  ['general', 'General fitness'],
+  ['fatloss', 'Lose fat'],
+  ['endurance', 'Endurance']
+]
+const EXPERIENCE = [
+  ['new', 'New to lifting'],
+  ['returning', 'Coming back after a break'],
+  ['regular', 'Training regularly']
+]
+const SESSION_MIN = [30, 45, 60, 75, 90]
+
+// Equipment options come from the library's own taxonomy, most common first, so every choice
+// on screen has exercises behind it.
+const EQUIPMENT = (() => {
+  const count = {}
+  EXDB.forEach(e => { if (e.eq) count[e.eq] = (count[e.eq] || 0) + 1 })
+  return Object.keys(count).sort((a, b) => count[b] - count[a]).slice(0, 14)
+})()
+
+const STEPS = ['goal', 'days', 'length', 'equipment', 'limits', 'extras']
+
+export default function CoachIntake() {
+  const nav = useNavigate()
+  const [params] = useSearchParams()
+  const editing = params.get('edit') === '1'
+  const S = useStore(s => s.S)
+  const user = useStore(s => s.user)
+  const config = useStore(s => s.config)
+  const update = useStore(s => s.update)
+  const toast = useUI(s => s.toast)
+  const [step, setStep] = useState(0)
+  const [busy, setBusy] = useState(false)
+  const [p, setP] = useState(() => ({
+    goal: null, experience: null, daysPerWeek: 3, preferredDays: [1, 3, 5],
+    sessionMin: 45, equipment: [], limitations: '', likes: '', dislikes: '', notes: '',
+    ...(S.coach?.profile || {})
+  }))
+  const set = patch => setP(v => ({ ...v, ...patch }))
+
+  if (!coachAvailable(config, user, { demo: DEMO, mobile: MOBILE })) { nav('/home', { replace: true }); return null }
+
+  const key = STEPS[step]
+  const canNext = key !== 'goal' || (p.goal && p.experience)
+  const last = step === STEPS.length - 1
+
+  const save = () => { update(s => { const c = (s.coach = s.coach || emptyCoach()); c.profile = p }) }
+
+  const finish = async () => {
+    save()
+    if (editing) { toast(t('Saved')); nav('/coach'); return }
+    setBusy(true)
+    try {
+      await requestPlan(p)
+      toast(t('The Coach is building your plan…'))
+      nav('/coach')
+    } catch (e) { toast(e.message || t('Could not ask the Coach')); setBusy(false) }
+  }
+
+  const toggleDay = d => set({
+    preferredDays: p.preferredDays.includes(d) ? p.preferredDays.filter(x => x !== d) : [...p.preferredDays, d].sort()
+  })
+  const toggleEq = e => set({
+    equipment: p.equipment.includes(e) ? p.equipment.filter(x => x !== e) : [...p.equipment, e]
+  })
+
+  return <div className="narrow">
+    <div className="hdr">
+      <button className="iconbtn" onClick={() => step ? setStep(step - 1) : nav('/coach')} aria-label={t('Back')}><Icon name="chevronLeft" /></button>
+      <div style={{ flex: 1, marginLeft: 10 }}>
+        <h1>{editing ? t('Coach profile') : t('Your plan')}</h1>
+        <div className="sub">{t('Step {0} of {1}', step + 1, STEPS.length)}</div>
+      </div>
+    </div>
+
+    {/* progress rail — the wizard's only chrome; six dots read faster than "1 of 6" alone */}
+    <div className="row" style={{ gap: 5, marginBottom: 14 }}>
+      {STEPS.map((s, i) => <div key={s} style={{
+        height: 3, flex: 1, borderRadius: 2,
+        background: i <= step ? 'var(--acc)' : 'var(--surface-3)'
+      }} />)}
+    </div>
+
+    <div className="card">
+      {key === 'goal' && <>
+        <h2 style={{ marginTop: 0 }}>{t('What are you training for?')}</h2>
+        <div className="sect-b">
+          {GOALS.map(([v, label]) => <button key={v} className="lrow tap" onClick={() => set({ goal: v })}>
+            <span className="lrow-m"><span className="lrow-t">{t(label)}</span></span>
+            {p.goal === v && <Icon name="check" className="lrow-k" />}
+          </button>)}
+        </div>
+        <h2>{t('Where are you starting from?')}</h2>
+        <div className="sect-b">
+          {EXPERIENCE.map(([v, label]) => <button key={v} className="lrow tap" onClick={() => set({ experience: v })}>
+            <span className="lrow-m"><span className="lrow-t">{t(label)}</span></span>
+            {p.experience === v && <Icon name="check" className="lrow-k" />}
+          </button>)}
+        </div>
+      </>}
+
+      {key === 'days' && <>
+        <h2 style={{ marginTop: 0 }}>{t('How many days a week?')}</h2>
+        <Segmented options={[2, 3, 4, 5, 6].map(n => ({ value: n, label: String(n) }))}
+          value={p.daysPerWeek} onChange={v => set({ daysPerWeek: v })} />
+        <div className="muted small" style={{ margin: '14px 0 8px' }}>{t('Which days suit you? (optional)')}</div>
+        <div className="week">
+          {[1, 2, 3, 4, 5, 6, 0].map(d => <div key={d} className={'wday' + (p.preferredDays.includes(d) ? ' today' : '')}
+            onClick={() => toggleDay(d)} style={{ cursor: 'pointer' }}>
+            <div className="lbl">{t(DAYN[d]).slice(0, 2)}</div>
+            <div className={'dot' + (p.preferredDays.includes(d) ? ' plan' : '')} />
+          </div>)}
+        </div>
+      </>}
+
+      {key === 'length' && <>
+        <h2 style={{ marginTop: 0 }}>{t('How long is a session?')}</h2>
+        <Segmented options={SESSION_MIN.map(n => ({ value: n, label: n + ' ' + t('min') }))}
+          value={p.sessionMin} onChange={v => set({ sessionMin: v })} />
+        <div className="muted small" style={{ marginTop: 12 }}>{t('The Coach fits the volume to the time you actually have, including rest between sets.')}</div>
+      </>}
+
+      {key === 'equipment' && <>
+        <h2 style={{ marginTop: 0 }}>{t('What can you train with?')}</h2>
+        <div className="muted small" style={{ marginBottom: 10 }}>{t('Pick everything you have access to. Leave it empty and the Coach will use the whole library.')}</div>
+        <div className="row" style={{ flexWrap: 'wrap', gap: 7 }}>
+          {EQUIPMENT.map(e => <button key={e} className={'chip' + (p.equipment.includes(e) ? ' on' : '')}
+            onClick={() => toggleEq(e)} style={{ textTransform: 'capitalize' }}>{e}</button>)}
+        </div>
+      </>}
+
+      {key === 'limits' && <>
+        <h2 style={{ marginTop: 0 }}>{t('Anything to work around?')}</h2>
+        <div className="muted small" style={{ marginBottom: 10 }}>
+          {t('Injuries, joints that complain, movements you cannot do, or practical limits like training at 6am in a flat.')}
+        </div>
+        <TextArea rows={4} maxLength={600} value={p.limitations} onChange={e => set({ limitations: e.target.value })}
+          placeholder={t('e.g. “dodgy left shoulder — no barbell overhead press”')} />
+        <div className="dim small" style={{ marginTop: 8, lineHeight: 1.5, color: 'var(--yellow)' }}>
+          {t('If something actually hurts, see a professional — the Coach will program conservatively but it cannot diagnose anything.')}
+        </div>
+      </>}
+
+      {key === 'extras' && <>
+        <h2 style={{ marginTop: 0 }}>{t('Anything else?')}</h2>
+        <div className="muted small" style={{ marginBottom: 6 }}>{t('Exercises you love')}</div>
+        <TextArea rows={2} maxLength={300} value={p.likes} onChange={e => set({ likes: e.target.value })} placeholder={t('e.g. “deadlifts, anything with a kettlebell”')} />
+        <div className="muted small" style={{ margin: '12px 0 6px' }}>{t('Exercises you would rather not')}</div>
+        <TextArea rows={2} maxLength={300} value={p.dislikes} onChange={e => set({ dislikes: e.target.value })} placeholder={t('e.g. “I hate lunges”')} />
+        <div className="muted small" style={{ margin: '12px 0 6px' }}>{t('Anything you want the Coach to know')}</div>
+        <TextArea rows={3} maxLength={600} value={p.notes} onChange={e => set({ notes: e.target.value })} placeholder={t('e.g. “I want visible arms progress by spring”')} />
+      </>}
+    </div>
+
+    <div className="row" style={{ gap: 10 }}>
+      {step > 0 && <Button onClick={() => setStep(step - 1)} style={{ flex: 1 }}>{t("Back")}</Button>}
+      {!last
+        ? <Button variant="primary" style={{ flex: 1 }} disabled={!canNext} onClick={() => setStep(step + 1)}>{t('Next')}</Button>
+        : <Button variant="primary" style={{ flex: 1 }} icon="sparkles" disabled={busy} onClick={finish}>
+          {editing ? t('Save') : t('Build my plan')}
+        </Button>}
+    </div>
+    {!canNext && <div className="dim small" style={{ textAlign: 'center', marginTop: 10 }}>{t('Pick a goal and where you are starting from to continue.')}</div>}
+    <div style={{ height: 20 }} />
+  </div>
+}

--- a/frontend/src/views/CoachProposal.jsx
+++ b/frontend/src/views/CoachProposal.jsx
@@ -1,0 +1,237 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useStore } from '../store/useStore.js'
+import { useUI } from '../store/useUI.js'
+import { t } from '../lib/i18n.js'
+import { fmtDate } from '../lib/format.js'
+import { exLine } from '../lib/history.js'
+import { loadOfRoutine } from '../lib/muscles.js'
+import { DEMO } from '../lib/demo.js'
+import { MOBILE } from '../lib/mobile.js'
+import {
+  markStale, applicable, applyChangeSet, applyCreatedPlan, recordDismissal,
+  changeTitle, changeValues, exName, coachAvailable
+} from '../lib/coach.js'
+import { useCoachStatus, resolvePending, refinePlan } from '../lib/coach-api.js'
+import { confirmSheet } from '../sheets.jsx'
+import Icon from '../components/Icon.jsx'
+import BodyMap from '../components/BodyMap.jsx'
+import { Button, Check, Switch, TextArea } from '../components/ui.jsx'
+
+/* Reviewing what the Coach came back with.
+ *
+ * The screen's whole job is to make approving something a decision rather than a formality:
+ * every change carries the evidence behind it, shows what it would replace, and starts
+ * accepted only because rejecting three of four is more common than accepting none. Anything
+ * that can no longer be applied is greyed out with a reason instead of silently vanishing. */
+
+export default function CoachProposal() {
+  const nav = useNavigate()
+  const S = useStore(s => s.S)
+  const user = useStore(s => s.user)
+  const config = useStore(s => s.config)
+  const update = useStore(s => s.update)
+  const toast = useUI(s => s.toast)
+  const { pending, loading, refresh } = useCoachStatus(true)
+
+  useEffect(() => { if (!coachAvailable(config, user, { demo: DEMO, mobile: MOBILE })) nav('/home', { replace: true }) }, [config, user])
+  useEffect(() => { if (!loading && !pending) nav('/coach', { replace: true }) }, [loading, pending])
+  if (!pending) return null
+
+  return pending.kind === 'create'
+    ? <CreatedPlan p={pending} S={S} update={update} toast={toast} nav={nav} refresh={refresh} />
+    : <ChangeSet p={pending} S={S} update={update} toast={toast} nav={nav} />
+}
+
+/* ============================ a created plan ============================ */
+
+function CreatedPlan({ p, S, update, toast, nav, refresh }) {
+  const [schedule, setSchedule] = useState(true)
+  const [refine, setRefine] = useState('')
+  const [busy, setBusy] = useState(false)
+  const b = p.bundle
+
+  const accept = () => {
+    try {
+      update(s => { applyCreatedPlan(s, p, { schedule }) })
+      resolvePending({ accepted: ['plan'] }).catch(() => {})
+      toast(t('Your plan is live'))
+      nav('/plan')
+    } catch (e) { toast(e.message || t('That proposal can’t be read.')) }
+  }
+  const discard = () => confirmSheet({
+    title: t('Discard this plan?'), message: t('Nothing is saved, and you can ask again anytime.'),
+    confirmText: t('Discard'), danger: true,
+    onConfirm: () => {
+      update(s => { recordDismissal(s, p) })
+      resolvePending({ dismissed: true }).catch(() => {})
+      nav('/coach')
+    }
+  })
+  const askRefine = async () => {
+    if (!refine.trim()) return
+    setBusy(true)
+    try {
+      await refinePlan(refine.trim())
+      setRefine('')
+      toast(t('The Coach is revising it…'))
+      nav('/coach')
+    } catch (e) { toast(e.message || t('Could not ask the Coach')); setBusy(false) }
+  }
+
+  return <div className="narrow">
+    <Header title={t('Your plan')} sub={p.iteration > 1 ? t('Revision {0}', p.iteration) : b.name} nav={nav} />
+
+    {!!b.summary && <div className="card"><div className="muted small" style={{ lineHeight: 1.55 }}>{b.summary}</div>
+      {!!b.basedOn && <div className="dim small" style={{ marginTop: 8 }}>{b.basedOn}</div>}</div>}
+
+    {b.routines.map(r => <div key={r.id} className="card">
+      <div className="row between" style={{ marginBottom: 4 }}>
+        <h2 style={{ margin: 0 }}>{r.emoji} {r.name}</h2>
+        <span className="dim small">{t('{0} exercises', r.ex.length)}</span>
+      </div>
+      {!!r.why && <div className="dim small" style={{ marginBottom: 10, lineHeight: 1.5 }}>{r.why}</div>}
+      {r.ex.map((e, i) => <div key={i} style={{ padding: '8px 0', borderTop: i ? '1px solid var(--sep)' : 'none' }}>
+        <div className="row between">
+          <span className="small capitalize" style={{ fontWeight: 500 }}>{exName(e.id)}</span>
+          <span className="small muted" style={{ whiteSpace: 'nowrap' }}>{exLine(e, S.unit)}</span>
+        </div>
+        {!!e.why && <div className="dim" style={{ fontSize: '.72rem', marginTop: 3, lineHeight: 1.4 }}>{e.why}</div>}
+      </div>)}
+      <div style={{ marginTop: 10 }}><BodyMap load={loadOfRoutine(r)} body={S.body} /></div>
+    </div>)}
+
+    <div className="card">
+      <div className="row between">
+        <div style={{ minWidth: 0 }}>
+          <div className="lrow-t">{t('Use this weekly schedule')}</div>
+          <div className="lrow-s">{t('Replaces your current week. Days this plan leaves empty become rest days.')}</div>
+        </div>
+        <Switch checked={schedule} onChange={setSchedule} />
+      </div>
+    </div>
+
+    <div className="card">
+      <h2 style={{ margin: '0 0 6px' }}>{t('Want something different?')}</h2>
+      <div className="muted small" style={{ marginBottom: 10 }}>{t('Say it in your own words and the Coach will revise the whole plan.')}</div>
+      <TextArea rows={2} maxLength={1000} value={refine} onChange={e => setRefine(e.target.value)}
+        placeholder={t('e.g. “swap the squats for split squats, and Mondays are short”')} />
+      <div style={{ height: 10 }} />
+      <Button icon="reset" disabled={busy || !refine.trim()} onClick={askRefine}>{t('Ask for a revision')}</Button>
+    </div>
+
+    <HealthNote />
+    <Button variant="primary" icon="check" onClick={accept}>{t('Accept plan')}</Button>
+    <div style={{ height: 8 }} />
+    <Button danger onClick={discard}>{t('Discard')}</Button>
+    <div style={{ height: 24 }} />
+  </div>
+}
+
+/* ============================ a change-set ============================ */
+
+function ChangeSet({ p, S, update, toast, nav }) {
+  // Staleness is decided against the *live* plan every render: someone may have edited it on
+  // another device while this screen was open.
+  const marked = useMemo(() => markStale(p, S), [p, S])
+  const usable = applicable(marked)
+  const [accepted, setAccepted] = useState(() => new Set(usable.map(c => c.id)))
+  const toggle = id => setAccepted(s => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n })
+
+  const apply = () => {
+    const ids = [...accepted].filter(id => usable.some(c => c.id === id))
+    if (!ids.length) { discard(); return }
+    try {
+      update(s => { applyChangeSet(s, marked, ids) })
+      resolvePending({ accepted: ids, rejected: marked.changes.filter(c => !ids.includes(c.id)).map(c => c.id) }).catch(() => {})
+      toast(t(ids.length === 1 ? '{0} change applied' : '{0} changes applied', ids.length))
+      nav('/plan')
+    } catch (e) { toast(e.message || t('Could not apply those changes')) }
+  }
+  const discard = () => confirmSheet({
+    title: t('Dismiss these suggestions?'), message: t('Nothing changes, and the Coach will remember you turned these down.'),
+    confirmText: t('Dismiss'), danger: true,
+    onConfirm: () => {
+      update(s => { recordDismissal(s, marked) })
+      resolvePending({ dismissed: true }).catch(() => {})
+      nav('/coach')
+    }
+  })
+
+  return <div className="narrow">
+    <Header title={t('Coach suggestions')} nav={nav}
+      sub={marked.evidence?.sessions
+        ? t('Based on your last {0} sessions', marked.evidence.sessions) +
+          (marked.evidence.from ? ` · ${fmtDate(marked.evidence.from)} – ${fmtDate(marked.evidence.to)}` : '')
+        : null} />
+
+    {!!marked.summary && <div className="card"><div className="muted small" style={{ lineHeight: 1.55 }}>{marked.summary}</div></div>}
+
+    {marked.planMoved && <div className="card" style={{ borderColor: 'var(--yellow)' }}>
+      <div className="row" style={{ gap: 9 }}>
+        <span className="lrow-i" style={{ '--tint': 'var(--yellow)' }}><Icon name="info" /></span>
+        <div className="small" style={{ lineHeight: 1.45 }}>
+          {t('Your plan changed since the Coach looked at it. Suggestions that no longer match are greyed out — ask for a fresh review to see them again.')}
+        </div>
+      </div>
+    </div>}
+
+    {marked.changes.map(c => {
+      const stale = c.status === 'stale'
+      const vals = changeValues(c)
+      return <div key={c.id} className="card" style={stale ? { opacity: .55 } : null}>
+        <div className="row between" style={{ gap: 10, alignItems: 'flex-start' }}>
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <div className="row" style={{ gap: 8, marginBottom: 3 }}>
+              <span className="small capitalize" style={{ fontWeight: 600 }}>{changeTitle(c)}</span>
+            </div>
+            {vals && <div className="row" style={{ gap: 7, marginBottom: 5 }}>
+              <span className="tag">{vals.before}</span>
+              <Icon name="chevronRight" style={{ fontSize: 12, color: 'var(--label-3)' }} />
+              <span className="tag acc">{vals.after}</span>
+            </div>}
+            <div className="dim small" style={{ lineHeight: 1.45 }}>{c.why}</div>
+            {stale && <div className="small" style={{ color: 'var(--yellow)', marginTop: 6 }}>
+              {t('Doesn’t match your plan any more — can’t be applied.')}
+            </div>}
+          </div>
+          {!stale && <Check checked={accepted.has(c.id)} onChange={() => toggle(c.id)} />}
+        </div>
+      </div>
+    })}
+
+    {!!marked.notes?.length && <div className="card">
+      <h2 style={{ margin: '0 0 8px' }}>{t('Notes from the Coach')}</h2>
+      {marked.notes.map((n, i) => <div key={i} className="muted small" style={{ lineHeight: 1.5, padding: '6px 0', borderTop: i ? '1px solid var(--sep)' : 'none' }}>{n}</div>)}
+      <div className="dim small" style={{ marginTop: 8 }}>{t('These change nothing on their own.')}</div>
+    </div>}
+
+    <HealthNote />
+    <Button variant="primary" icon="check" onClick={apply}>
+      {accepted.size ? t(accepted.size === 1 ? 'Apply {0} change' : 'Apply {0} changes', accepted.size) : t('Apply nothing')}
+    </Button>
+    <div style={{ height: 8 }} />
+    <Button danger onClick={discard}>{t('Dismiss all')}</Button>
+    <div style={{ height: 24 }} />
+  </div>
+}
+
+/* The hub and the intake screen both carry this; the screen where changes are actually accepted
+   did not, which is the one place it matters most — this is the tap that changes what somebody
+   will do with their body next week. Deliberately immediately above the accept button rather
+   than at the top of a scrolling page, so it is on screen at the moment of the decision. */
+function HealthNote() {
+  return <div className="dim small" style={{ lineHeight: 1.5, margin: '4px 0 12px', color: 'var(--yellow)' }}>
+    {t('The Coach is not a doctor or a physiotherapist. If something hurts, ask a professional.')}
+  </div>
+}
+
+function Header({ title, sub, nav }) {
+  return <div className="hdr">
+    <button className="iconbtn" onClick={() => nav('/coach')} aria-label={t('Back')}><Icon name="chevronLeft" /></button>
+    <div style={{ flex: 1, marginLeft: 10 }}>
+      <h1>{title}</h1>
+      {sub && <div className="sub">{sub}</div>}
+    </div>
+  </div>
+}


### PR DESCRIPTION
**4/6 — the UI.** Stacked on [#46](https://github.com/DuarteSantos8/openGym/pull/46) (and so on [#45](https://github.com/DuarteSantos8/openGym/pull/45)); it collapses to a single commit as those merge.

Coach hub, six-screen intake, proposal review with per-change accept/reject, and the admin card — wired into `App.jsx` and `Admin.jsx`. `AdminCoach` renders nothing unless the instance offers the Coach, so an admin page on a box that never enabled it is byte-for-byte the page it was.

## The four things I owed you

**The `CoachProposal` disclaimer.** I flagged this in the first round: the hub and the intake screen both carry a health note and the *accept* screen did not — the one place it matters, because that tap changes what somebody does with their body next week. It now sits immediately above the accept button on both proposal kinds, not at the top of a scrolling page, so it is on screen at the moment of the decision.

**"Jobs run unprivileged: yes/no."** The card never showed it. `canDropPrivileges()` fails closed, so when the answer is no *nothing runs at all* — and the admin was left to learn that from a user reporting that the Coach does nothing. It now states the verdict, and the server's own `why` when it is no.

**Whose account is being spent.** Your constraint was that the admin card and the user's Coach screen must both name it. That was in neither. `coach-api.js` gained the `/api/coach/account` call — the route 1/6 built and nothing had used since — and the card states the mode plainly, including that in instance mode every profile after the first is refused.

**The refusal path** is reachable from the client now rather than being a server-side string nobody could see.

## Something worse than a gap

The credential UI was wired to a server shape that does not exist. It read `d.auth.state`, which `GET /api/admin/coach` never sent, and posted to `/auth/setup-token`, `/auth/key` and `/auth/disconnect` — none of which are routes. **Every credential button on the card was dead.** It now uses the `connect`/`disconnect` routes from 3/6, and the admin payload carries an `auth` summary: state, type, and the account label, never the credential itself. `unreadable` is its own state rather than folding into "not connected", because `./data` restored without its `secret` has a specific cause and a specific fix.

The setup-token sheet also gained an optional "whose account is this?" field — that label is what both surfaces show when they name the account.

## Left out on purpose

The ChatGPT device-login sheet. It is Codex's, it calls routes that do not exist, and Codex is 6/6 — so it comes back with the provider it belongs to rather than shipping here as unreachable UI.

## Verified

api **72/72**, frontend **404/404**, build clean, 11 locales in sync at 628 keys. The new user-facing strings fall back to English until 5/6 adds them — the locale gate compares the eleven files against each other, so it passes either way.