### PR TITLE
Session UX: warm-up phase separation, warm-up set management, weight cascade

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -559,6 +559,9 @@ h4.sec{
 .setrow+.setrow::before{
   content:'';position:absolute;left:32px;right:0;top:0;height:var(--hair);background:var(--sep);
 }
+.setph{margin:8px 0 2px;font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--dim);display:flex;align-items:center;gap:10px}
+.setph::after{content:'';flex:1;height:1px;background:var(--sep)}
+.setsep{height:1px;background:var(--sep);margin:9px 0}
 .setrow .n{
   width:24px;height:24px;border-radius:50%;background:var(--surface-2);color:var(--label-2);
   display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:500;flex:none;

--- a/frontend/src/lib/effort.js
+++ b/frontend/src/lib/effort.js
@@ -44,7 +44,7 @@ export const scaleName = kind => EFFORT[kind].hd
 function eachDoneSet(S, fn) {
   ;(S.workouts || []).forEach(w =>
     (w.entries || []).forEach(e =>
-      (e.sets || []).forEach(s => { if (s.done) fn(s, w, e) })))
+      (e.sets || []).forEach(s => { if (s.done && !s.warmup) fn(s, w, e) })))
 }
 
 // A window in days, counted back from now. 0 = everything, which is also what an empty

--- a/frontend/src/lib/history.js
+++ b/frontend/src/lib/history.js
@@ -270,3 +270,49 @@ export function streakWeeks(S) {
   }
   return streak
 }
+
+/**
+ * Cascade a weight change forward: following sets of the same warm-up flag that are still
+ * undone take the new value (null deletes the key). Done sets are never rewritten.
+ */
+export function cascadeWeight(rows, from, value) {
+  const warm = !!rows[from]?.warmup
+  const next = rows.slice()
+  for (let j = from + 1; j < next.length; j++) {
+    if (!!next[j].warmup === warm && !next[j].done) {
+      if (value == null) delete next[j].w
+      else next[j].w = value
+    }
+  }
+  return next
+}
+
+/** Insert a warm-up row before the first work row, copying the preceding warm-up's values. */
+export function insertWarmupRow(rows, mode, target) {
+  const firstWork = rows.findIndex(x => !x.warmup)
+  const at = firstWork === -1 ? rows.length : firstWork
+  const l = rows[at - 1] || rows[rows.length - 1]
+  const warm = mode === 'cardio'
+    ? { min: l ? l.min : (target.min || 20), speed: l ? l.speed : (target.speed || 8), done: false, warmup: true }
+    : mode === 'time'
+      ? { sec: l ? l.sec : (target.sec || 45), w: l ? (l.w || 0) : (target.weight || 0), done: false, warmup: true }
+      : { w: l ? l.w : 0, r: l ? l.r : target.reps, done: false, warmup: true }
+  const next = rows.slice()
+  next.splice(at, 0, warm)
+  return next
+}
+
+/** Remove the row at `i`, never emptying the entry below one row. */
+export function removeRowAt(rows, i) {
+  if (rows.length <= 1) return rows.slice()
+  const next = rows.slice()
+  next.splice(i, 1)
+  return next
+}
+
+/** Completed non-warm-up sets across a workout's entries. */
+export function workSetsDone(w) {
+  return (w?.entries || []).reduce(
+    (n, e) => n + (e.sets || []).filter(s => s.done && !s.warmup).length, 0,
+  )
+}

--- a/frontend/src/lib/history.test.js
+++ b/frontend/src/lib/history.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { modeOf, isTimed, fmtSec, setLabel, defaultConfig, buildSets, freestyleConfig, exLine, workoutVolume, effortOf, stepEffort, capEffort, isBw, isPerSide, sideReps, repStep } from './history.js'
+import { modeOf, isTimed, fmtSec, setLabel, defaultConfig, buildSets, freestyleConfig, exLine, workoutVolume, effortOf, stepEffort, capEffort, isBw, isPerSide, sideReps, repStep, cascadeWeight, insertWarmupRow, removeRowAt } from './history.js'
 import { EXDB } from './exercises.js'
 
 // Real ids out of the shipped catalogue, so the body-part fallback is exercised for real.
@@ -476,5 +476,56 @@ describe('workoutVolume', () => {
   it('leaves an unloaded bodyweight set at zero volume rather than inventing a number', () => {
     const w = { entries: [{ id: BW, target: { bodyweight: true }, sets: [{ w: 0, r: 20, done: true }] }] }
     expect(workoutVolume(w)).toBe(0)
+  })
+})
+
+
+describe('session row helpers', () => {
+  it('cascadeWeight propagates to same-flag undone rows and never rewrites done sets', () => {
+    const rows = [
+      { warmup: true, w: 20, done: true },
+      { warmup: true, w: 20, done: false },
+      { w: 60, done: true },
+      { w: 60, done: false },
+      { w: 60, done: false },
+    ]
+    const next = cascadeWeight(rows, 2, 62.5)
+    expect(next[2].w).toBe(60)             // done set untouched
+    expect(next[3].w).toBe(62.5)           // same flag (work), undone
+    expect(next[4].w).toBe(62.5)           // same flag (work), undone
+    expect(next[1].w).toBe(20)             // different flag (warm-up) untouched
+  })
+
+  it('cascadeWeight deleting the weight removes the key from following undone rows only', () => {
+    const rows = [
+      { w: 60, done: true },
+      { w: 60, done: false },
+      { w: 60, done: false },
+    ]
+    const next = cascadeWeight(rows, 0, null)
+    expect(next[0].w).toBe(60)             // done set untouched
+    expect('w' in next[1]).toBe(false)
+    expect('w' in next[2]).toBe(false)
+  })
+
+  it('insertWarmupRow inserts before the first work row and copies the last warm-up values', () => {
+    const rows = [
+      { warmup: true, w: 20, r: 8, done: true },
+      { warmup: true, w: 30, r: 8, done: false },
+      { w: 60, r: 8, done: false },
+    ]
+    const next = insertWarmupRow(rows, 'reps', { reps: 8 })
+    expect(next.length).toBe(4)
+    expect(next[2].warmup).toBe(true)
+    expect(next[2].w).toBe(30)             // copies the preceding warm-up
+    expect(next[3].w).toBe(60)             // work row still after the warm-up block
+  })
+
+  it('removeRowAt never empties an entry below one row', () => {
+    expect(removeRowAt([{ w: 60 }], 0).length).toBe(1)
+    const rows = [{ w: 60 }, { w: 70 }]
+    const next = removeRowAt(rows, 0)
+    expect(next.length).toBe(1)
+    expect(next[0].w).toBe(70)
   })
 })

--- a/frontend/src/lib/muscles.js
+++ b/frontend/src/lib/muscles.js
@@ -108,7 +108,7 @@ export function loadOf(items) {
  */
 export const loadOfWorkouts = (workouts, pick) =>
   loadOf((workouts || []).flatMap(w =>
-    (w.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && (!pick || pick(s))).length }))))
+    (w.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && !s.warmup && (!pick || pick(s))).length }))))
 
 /** Load a routine *would* produce, from its planned set counts. */
 export const loadOfRoutine = routine =>
@@ -116,7 +116,7 @@ export const loadOfRoutine = routine =>
 
 /** Load for a workout still in progress — the sets ticked so far. */
 export const loadOfActive = active =>
-  loadOf((active?.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done).length })))
+  loadOf((active?.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && !s.warmup).length })))
 
 /**
  * Shade buckets 0–4 per muscle.

--- a/frontend/src/lib/onerm.js
+++ b/frontend/src/lib/onerm.js
@@ -44,7 +44,7 @@ export function estimate1RM(w, r, formula = DEFAULT_FORMULA) {
 export function bestSetOf(entry, formula = DEFAULT_FORMULA) {
   let best = null
   ;(entry?.sets || []).forEach(s => {
-    if (!s.done) return
+    if (!s.done || s.warmup) return
     const est = estimate1RM(s.w, s.r, formula)
     if (est !== null && (!best || est > best.est)) best = { est, w: Number(s.w), r: Math.round(Number(s.r)) }
   })

--- a/frontend/src/lib/onerm.test.js
+++ b/frontend/src/lib/onerm.test.js
@@ -146,3 +146,19 @@ describe('is1RMRecord', () => {
     expect(is1RMRecord(S, 'bench', { id: 'bench', sets: [{ w: 200, r: 5, done: false }] })).toBeNull()
   })
 })
+
+
+describe('warm-up sets and 1RM', () => {
+  const ENTRY = { id: 'warm-test', sets: [
+    { w: 20, r: 8, done: true, warmup: true },
+    { w: 80, r: 5, done: true },
+  ] }
+
+  it('does not let a ticked-off warm-up set set or raise the estimated 1RM', () => {
+    const working = { id: 'warm-test', sets: [{ w: 80, r: 5, done: true }] }
+    expect(bestSetOf(ENTRY)).toEqual(bestSetOf(working))
+    expect(best1RM({ workouts: [{ entries: [ENTRY] }] }, 'warm-test')).toBe(
+      best1RM({ workouts: [{ entries: [working] }] }, 'warm-test'),
+    )
+  })
+})

--- a/frontend/src/lib/onerm.test.js
+++ b/frontend/src/lib/onerm.test.js
@@ -157,7 +157,7 @@ describe('warm-up sets and 1RM', () => {
   it('does not let a ticked-off warm-up set set or raise the estimated 1RM', () => {
     const working = { id: 'warm-test', sets: [{ w: 80, r: 5, done: true }] }
     expect(bestSetOf(ENTRY)).toEqual(bestSetOf(working))
-    expect(best1RM({ workouts: [{ entries: [ENTRY] }] }, 'warm-test')).toBe(
+    expect(best1RM({ workouts: [{ entries: [ENTRY] }] }, 'warm-test')).toEqual(
       best1RM({ workouts: [{ entries: [working] }] }, 'warm-test'),
     )
   })

--- a/frontend/src/lib/progression.js
+++ b/frontend/src/lib/progression.js
@@ -101,7 +101,9 @@ function deloadTo(cur, step) {
 export function readSession(entry, fallback) {
   const target = (entry && entry.target) || fallback || {}
   const mode = modeOf({ ...target, id: entry && entry.id })
-  const sets = (entry && entry.sets) || []
+  // Warm-up rows are prep, not the session: one filtered read beats guarding every consumer
+  // below (an undone warm-up otherwise poisons `ok` forever and its reps drag `low`/`count`).
+  const sets = ((entry && entry.sets) || []).filter(s => !s.warmup)
   const planned = target.sets || sets.length
   const enough = sets.length >= planned
 
@@ -110,7 +112,7 @@ export function readSession(entry, fallback) {
     const held = sets.map(s => (s.done ? (s.sec || 0) : 0))
     return {
       mode, goal, held,
-      weight: Math.max(0, ...sets.filter(s => s.done && !s.warmup).map(s => s.w || 0)),
+      weight: Math.max(0, ...sets.filter(s => s.done).map(s => s.w || 0)),
       best: Math.max(0, ...held),
       ok: goal > 0 && enough && held.length > 0 && held.every(h => h >= goal)
     }
@@ -119,7 +121,7 @@ export function readSession(entry, fallback) {
   const reps = sets.map(s => (s.done ? (s.r || 0) : 0))
   return {
     mode, goal, reps,
-    weight: Math.max(0, ...sets.filter(s => s.done && !s.warmup).map(s => s.w || 0)),
+    weight: Math.max(0, ...sets.filter(s => s.done).map(s => s.w || 0)),
     count: reps.length,                                   // the dimension bodyweight work grows (#33)
     low: reps.length ? Math.min(...reps) : 0,
     amrap: reps.length ? reps[reps.length - 1] : 0,       // Greyskull's final set
@@ -250,7 +252,10 @@ export function nextPrescription(S, cfg, routine) {
 export function applyPrescription(sets, p) {
   if (!p || p.kind === 'off' || p.kind === 'first') return sets
   const out = sets.map(s => {
-    if (s.done && !s.warmup) return s
+    // Never rewrite a logged set, and never rewrite a warm-up: the prescription speaks to
+    // the work rows only (a ticked warm-up falling through here would be the data-loss the
+    // cascade fix removed, two files over).
+    if (s.done || s.warmup) return s
     const o = { ...s }
     if (p.weight != null) o.w = p.weight
     if (p.reps != null) o.r = p.reps
@@ -260,9 +265,10 @@ export function applyPrescription(sets, p) {
   // A policy that decided on a set count gets to grow the list — bodyweight progression adds
   // a set where a barbell would have added a plate. Only ever upwards, and only by copying a
   // row that is already there: a session in progress must not lose a set it has logged.
-  if (p.sets > out.length) {
-    const seed = out[out.length - 1]
-    while (out.length < p.sets) out.push({ ...seed, done: false })
+  const workRows = out.filter(s => !s.warmup)
+  if (p.sets > workRows.length) {
+    const seed = workRows[workRows.length - 1] || out[out.length - 1]
+    while (out.filter(s => !s.warmup).length < p.sets) out.push({ ...seed, done: false })
   }
   return out
 }

--- a/frontend/src/lib/progression.js
+++ b/frontend/src/lib/progression.js
@@ -110,7 +110,7 @@ export function readSession(entry, fallback) {
     const held = sets.map(s => (s.done ? (s.sec || 0) : 0))
     return {
       mode, goal, held,
-      weight: Math.max(0, ...sets.filter(s => s.done).map(s => s.w || 0)),
+      weight: Math.max(0, ...sets.filter(s => s.done && !s.warmup).map(s => s.w || 0)),
       best: Math.max(0, ...held),
       ok: goal > 0 && enough && held.length > 0 && held.every(h => h >= goal)
     }
@@ -119,7 +119,7 @@ export function readSession(entry, fallback) {
   const reps = sets.map(s => (s.done ? (s.r || 0) : 0))
   return {
     mode, goal, reps,
-    weight: Math.max(0, ...sets.filter(s => s.done).map(s => s.w || 0)),
+    weight: Math.max(0, ...sets.filter(s => s.done && !s.warmup).map(s => s.w || 0)),
     count: reps.length,                                   // the dimension bodyweight work grows (#33)
     low: reps.length ? Math.min(...reps) : 0,
     amrap: reps.length ? reps[reps.length - 1] : 0,       // Greyskull's final set
@@ -132,7 +132,7 @@ export function sessionsFor(S, exId, fallback) {
   const out = []
   ;(S.workouts || []).forEach(w => {
     const entry = w.entries.find(e => e.id === exId)
-    if (entry && entry.sets.some(s => s.done)) out.push({ d: w.d, ...readSession(entry, fallback) })
+    if (entry && entry.sets.some(s => s.done && !s.warmup)) out.push({ d: w.d, ...readSession(entry, fallback) })
   })
   return out
 }
@@ -250,7 +250,7 @@ export function nextPrescription(S, cfg, routine) {
 export function applyPrescription(sets, p) {
   if (!p || p.kind === 'off' || p.kind === 'first') return sets
   const out = sets.map(s => {
-    if (s.done) return s
+    if (s.done && !s.warmup) return s
     const o = { ...s }
     if (p.weight != null) o.w = p.weight
     if (p.reps != null) o.r = p.reps

--- a/frontend/src/lib/progression.test.js
+++ b/frontend/src/lib/progression.test.js
@@ -450,3 +450,56 @@ describe('applyPrescription', () => {
     expect(applyPrescription(sets, { kind: 'up', weight: 60, sets: 1 })).toHaveLength(sets.length)
   })
 })
+
+
+describe('warm-up rows in session reads (round 3)', () => {
+  it('readSession ignores warm-up rows for reps, count, low and ok', () => {
+    // An undone warm-up (r 0) must not poison `ok` forever; its lighter reps must not
+    // drag `low`/`count` - the warm-up is prep, the session is the work rows.
+    const s = readSession({ id: LIFT, target: { sets: 2, reps: 5, mode: 'reps' }, sets: [
+      { w: 20, r: 8, done: true, warmup: true },
+      { w: 60, r: 5, done: true },
+      { w: 60, r: 6, done: true },
+    ] })
+    expect(s.count).toBe(2)
+    expect(s.low).toBe(5)
+    expect(s.reps).toEqual([5, 6])
+    expect(s.ok).toBe(true)
+  })
+
+  it('readSession keeps an undone warm-up out of held/ok in time mode', () => {
+    const s = readSession({ id: LIFT, target: { sets: 2, sec: 45, mode: 'time' }, sets: [
+      { sec: 45, done: true, warmup: true },
+      { sec: 45, done: true },
+      { sec: 30, done: true },
+    ] })
+    expect(s.held).toEqual([45, 30])
+    expect(s.ok).toBe(false) // the 30s work row is the miss, not the warm-up
+  })
+})
+
+describe('applyPrescription never touches warm-up rows (round 3)', () => {
+  it('leaves a done warm-up exactly as logged', () => {
+    const sets = [
+      { w: 20, r: 8, done: true, warmup: true },
+      { w: 60, r: 5, done: true },
+      { w: 60, r: 5, done: false },
+    ]
+    const out = applyPrescription(sets, { kind: 'up', weight: 62.5, reps: 5 })
+    expect(out[0]).toEqual({ w: 20, r: 8, done: true, warmup: true })
+    expect(out[1]).toEqual({ w: 60, r: 5, done: true })
+    expect(out[2]).toEqual({ w: 62.5, r: 5, done: false })
+  })
+
+  it('grows the work rows, not the warm-up rows, when the policy adds sets', () => {
+    const sets = [
+      { w: 20, r: 8, done: true, warmup: true },
+      { w: 60, r: 5, done: true },
+      { w: 60, r: 5, done: false },
+    ]
+    const out = applyPrescription(sets, { kind: 'up', weight: 62.5, reps: 5, sets: 4 })
+    expect(out.filter(s => !s.warmup)).toHaveLength(4) // 2 existing + 2 grown
+    expect(out.filter(s => s.warmup)).toHaveLength(1)  // warm-up untouched
+    expect(out[0]).toEqual({ w: 20, r: 8, done: true, warmup: true })
+  })
+})

--- a/frontend/src/locales/de.js
+++ b/frontend/src/locales/de.js
@@ -161,6 +161,8 @@ export default {
   'Last time you hit all reps — try {0}': 'Letztes Mal alle Wdh. geschafft — versuch {0}',
   'Weights bumped to {0}': 'Gewichte auf {0} erhöht',
   'Remove set': 'Satz entfernen',
+  'Warm-up': 'Aufwärmen',
+  'Add warm-up set': 'Aufwärmsatz hinzufügen',
   'Add set': 'Satz hinzufügen',
   'Cardio logged': 'Cardio eingetragen',
   'Discard workout?': 'Training verwerfen?',

--- a/frontend/src/locales/de.js
+++ b/frontend/src/locales/de.js
@@ -583,4 +583,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{0} Sätze mit {1} — Zeit für Zusatzgewicht oder eine schwerere Variante.',
   '{0} per side': '{0} pro Seite',
   'You still log the total: {0} is {1} per side.': 'Du trägst weiterhin die Gesamtzahl ein: {0} sind {1} pro Seite.',
+  '{0} sets · {1} work': '{0} Sätze · {1} Arbeit',
 }

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -566,4 +566,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{0} series de {1}: toca añadir peso o pasar a una variante más difícil.',
   '{0} per side': '{0} por lado',
   'You still log the total: {0} is {1} per side.': 'Sigues registrando el total: {0} son {1} por lado.',
+  '{0} sets · {1} work': '{0} series · {1} trabajo',
 }

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -154,6 +154,8 @@ export default {
   'Last time you hit all reps — try {0}': 'La última vez completaste todas las reps — prueba {0}',
   'Weights bumped to {0}': 'Pesos subidos a {0}',
   'Remove set': 'Quitar serie',
+  'Warm-up': 'Calentamiento',
+  'Add warm-up set': 'Añadir serie de calentamiento',
   'Add set': 'Añadir serie',
   'Cardio logged': 'Cardio registrado',
   'Discard workout?': '¿Descartar entrenamiento?',

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -566,4 +566,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{0} séries de {1} — il est temps d’ajouter du poids ou de passer à une variante plus dure.',
   '{0} per side': '{0} par côté',
   'You still log the total: {0} is {1} per side.': 'Tu notes toujours le total : {0}, c’est {1} par côté.',
+  '{0} sets · {1} work': '{0} séries · {1} travail',
 }

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -154,6 +154,8 @@ export default {
   'Last time you hit all reps — try {0}': 'Toutes les reps réussies la dernière fois — essaie {0}',
   'Weights bumped to {0}': 'Poids montés à {0}',
   'Remove set': 'Retirer une série',
+  'Warm-up': 'Échauffement',
+  'Add warm-up set': 'Ajouter une série d’échauffement',
   'Add set': 'Ajouter une série',
   'Cardio logged': 'Cardio noté',
   'Discard workout?': 'Abandonner la séance ?',

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -154,6 +154,8 @@ export default {
   'Last time you hit all reps — try {0}': 'पिछली बार सारे रेप्स पूरे किए — {0} आज़माएँ',
   'Weights bumped to {0}': 'वज़न बढ़ाकर {0} किया',
   'Remove set': 'सेट हटाएँ',
+  'Warm-up': 'वार्म-अप',
+  'Add warm-up set': 'वार्म-अप सेट जोड़ें',
   'Add set': 'सेट जोड़ें',
   'Cardio logged': 'कार्डियो दर्ज हुआ',
   'Discard workout?': 'वर्कआउट छोड़ें?',

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -566,4 +566,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{1} रेप्स के {0} सेट — अब वज़न बढ़ाने या किसी कठिन वैरिएशन पर जाने का समय।',
   '{0} per side': 'प्रति तरफ़ {0}',
   'You still log the total: {0} is {1} per side.': 'आप कुल ही दर्ज करते हैं: {0} यानी प्रति तरफ़ {1}।',
+  '{0} sets · {1} work': '{0} सेट · {1} काम',
 }

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -154,6 +154,8 @@ export default {
   'Last time you hit all reps — try {0}': "L'ultima volta hai completato tutte le rip. — prova {0}",
   'Weights bumped to {0}': 'Pesi aumentati a {0}',
   'Remove set': 'Rimuovi serie',
+  'Warm-up': 'Riscaldamento',
+  'Add warm-up set': 'Aggiungi serie di riscaldamento',
   'Add set': 'Aggiungi serie',
   'Cardio logged': 'Cardio registrato',
   'Discard workout?': 'Scartare allenamento?',

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -566,4 +566,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{0} serie da {1} — è ora di aggiungere peso o passare a una variante più difficile.',
   '{0} per side': '{0} per lato',
   'You still log the total: {0} is {1} per side.': 'Registri sempre il totale: {0} sono {1} per lato.',
+  '{0} sets · {1} work': '{0} serie · {1} lavoro',
 }

--- a/frontend/src/locales/ko.js
+++ b/frontend/src/locales/ko.js
@@ -566,4 +566,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{1}회 {0}세트 — 이제 무게를 올리거나 더 어려운 동작으로 넘어가세요.',
   '{0} per side': '한쪽당 {0}회',
   'You still log the total: {0} is {1} per side.': '기록은 그대로 합계로 합니다: {0}회는 한쪽당 {1}회입니다.',
+  '{0} sets · {1} work': '{0} 세트 · {1} 작업',
 }

--- a/frontend/src/locales/ko.js
+++ b/frontend/src/locales/ko.js
@@ -154,6 +154,8 @@ export default {
   'Last time you hit all reps — try {0}': '지난번에 모든 횟수를 채웠어요 — {0}에 도전해 보세요',
   'Weights bumped to {0}': '무게를 {0}(으)로 올렸어요',
   'Remove set': '세트 빼기',
+  'Warm-up': '워밍업',
+  'Add warm-up set': '워밍업 세트 추가',
   'Add set': '세트 추가',
   'Cardio logged': '유산소 기록됨',
   'Discard workout?': '운동을 버릴까요?',

--- a/frontend/src/locales/pl.js
+++ b/frontend/src/locales/pl.js
@@ -154,6 +154,8 @@ export default {
   'Last time you hit all reps — try {0}': 'Ostatnio zrobiłeś wszystkie powtórzenia — spróbuj {0}',
   'Weights bumped to {0}': 'Ciężary podniesione do {0}',
   'Remove set': 'Usuń serię',
+  'Warm-up': 'Rozgrzewka',
+  'Add warm-up set': 'Dodaj serię rozgrzewkową',
   'Add set': 'Dodaj serię',
   'Cardio logged': 'Cardio zapisane',
   'Discard workout?': 'Odrzucić trening?',

--- a/frontend/src/locales/pl.js
+++ b/frontend/src/locales/pl.js
@@ -566,4 +566,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{0} × {1} powt. — czas dodać ciężar albo przejść na trudniejszy wariant.',
   '{0} per side': '{0} na stronę',
   'You still log the total: {0} is {1} per side.': 'Nadal zapisujesz łączną liczbę: {0} to {1} na stronę.',
+  '{0} sets · {1} work': '{0} serii · {1} praca',
 }

--- a/frontend/src/locales/pt.js
+++ b/frontend/src/locales/pt.js
@@ -154,6 +154,8 @@ export default {
   'Last time you hit all reps — try {0}': 'Da última vez completaste todas as reps — tenta {0}',
   'Weights bumped to {0}': 'Pesos aumentados para {0}',
   'Remove set': 'Remover série',
+  'Warm-up': 'Aquecimento',
+  'Add warm-up set': 'Adicionar série de aquecimento',
   'Add set': 'Adicionar série',
   'Cardio logged': 'Cardio registado',
   'Discard workout?': 'Descartar treino?',

--- a/frontend/src/locales/pt.js
+++ b/frontend/src/locales/pt.js
@@ -566,4 +566,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{0} séries de {1} — hora de acrescentar peso ou passar a uma variação mais difícil.',
   '{0} per side': '{0} por lado',
   'You still log the total: {0} is {1} per side.': 'Continuas a registar o total: {0} são {1} por lado.',
+  '{0} sets · {1} work': '{0} séries · {1} trabalho',
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -566,4 +566,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{0} × {1} — пора добавить вес или перейти к более сложному варианту.',
   '{0} per side': '{0} на сторону',
   'You still log the total: {0} is {1} per side.': 'Ты по-прежнему записываешь общее число: {0} — это {1} на сторону.',
+  '{0} sets · {1} work': '{0} подходов · {1} рабочих',
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -154,6 +154,8 @@ export default {
   'Last time you hit all reps — try {0}': 'В прошлый раз все повторения сделаны — попробуй {0}',
   'Weights bumped to {0}': 'Веса подняты до {0}',
   'Remove set': 'Убрать подход',
+  'Warm-up': 'Разминка',
+  'Add warm-up set': 'Добавить разминочный подход',
   'Add set': 'Добавить подход',
   'Cardio logged': 'Кардио записано',
   'Discard workout?': 'Отменить тренировку?',

--- a/frontend/src/locales/tr.js
+++ b/frontend/src/locales/tr.js
@@ -154,6 +154,8 @@ export default {
   'Last time you hit all reps — try {0}': 'Geçen sefer tüm tekrarları yaptın — {0} dene',
   'Weights bumped to {0}': 'Ağırlıklar {0} değerine çıkarıldı',
   'Remove set': 'Set kaldır',
+  'Warm-up': 'Isınma',
+  'Add warm-up set': 'Isınma seti ekle',
   'Add set': 'Set ekle',
   'Cardio logged': 'Kardiyo kaydedildi',
   'Discard workout?': 'Antrenman iptal edilsin mi?',

--- a/frontend/src/locales/tr.js
+++ b/frontend/src/locales/tr.js
@@ -566,4 +566,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{1} tekrarlık {0} set — ağırlık ekleme ya da daha zor bir varyasyona geçme zamanı.',
   '{0} per side': 'Taraf başına {0}',
   'You still log the total: {0} is {1} per side.': 'Toplamı kaydetmeye devam ediyorsun: {0}, taraf başına {1} demek.',
+  '{0} sets · {1} work': '{0} set · {1} çalışma',
 }

--- a/frontend/src/locales/zh.js
+++ b/frontend/src/locales/zh.js
@@ -154,6 +154,8 @@ export default {
   'Last time you hit all reps — try {0}': '上次完成了所有次数——试试 {0}',
   'Weights bumped to {0}': '重量已提升到 {0}',
   'Remove set': '减一组',
+  'Warm-up': '热身',
+  'Add warm-up set': '添加热身组',
   'Add set': '加一组',
   'Cardio logged': '有氧已记录',
   'Discard workout?': '放弃训练？',

--- a/frontend/src/locales/zh.js
+++ b/frontend/src/locales/zh.js
@@ -566,4 +566,5 @@ export default {
   '{0} sets of {1} — time to add weight or move to a harder variation.': '{0} 组 × {1} 次——该加重量或换更难的变式了。',
   '{0} per side': '每侧 {0} 次',
   'You still log the total: {0} is {1} per side.': '你记录的仍然是总数：{0} 表示每侧 {1} 次。',
+  '{0} sets · {1} work': '{0} 组 · {1} 工作',
 }

--- a/frontend/src/sheets.jsx
+++ b/frontend/src/sheets.jsx
@@ -3,7 +3,7 @@ import { useStore } from './store/useStore.js'
 import { useUI } from './store/useUI.js'
 import { EXDB, EXIDX, BODYPARTS, isCardio, isBodyweightEq, allExercises, equipmentOf } from './lib/exercises.js'
 import { fmtDate, fmtNum, fmtVol, fmtDur, durPart, todayISO, uid, exCount, DAYN, MONTHS_LONG, ACCENTS } from './lib/format.js'
-import { lastEntryFor, bestWeightFor, buildSets, effectiveRoutineId, workoutVolume, setsDone, setsDoneActive, lastBW, supersetUnits, unitOf, setLabel, defaultConfig, cleanupSg, modeOf, effortOf, isBw, isPerSide, sideReps } from './lib/history.js'
+import { lastEntryFor, bestWeightFor, buildSets, effectiveRoutineId, workoutVolume, setsDone, setsDoneActive, lastBW, supersetUnits, unitOf, setLabel, defaultConfig, cleanupSg, modeOf, effortOf, isBw, isPerSide, sideReps, workSetsDone } from './lib/history.js'
 import { beep, vibrate } from './lib/sound.js'
 import { t, instrFor, getLang, INSTR_LANGS } from './lib/i18n.js'
 import { nav } from './lib/nav.js'
@@ -910,7 +910,7 @@ function FinishSummary({ w, prs, e1prs = [], close }) {
     <div className="tiles" style={{ textAlign: 'left' }}>
       <div className="tile"><div className="l">{t('Duration')}</div><div className="v" style={{ fontSize: '1.1rem' }}>{fmtDur(w.end - w.start)}</div></div>
       <div className="tile"><div className="l">{t('Volume')}</div><div className="v" style={{ fontSize: '1.1rem' }}>{fmtVol(w.vol, st.unit)}</div></div>
-      <div className="tile"><div className="l">{t('Sets')}</div><div className="v" style={{ fontSize: '1.1rem' }}>{setsDone(w)}</div></div>
+      <div className="tile"><div className="l">{t('Sets')}</div><div className="v" style={{ fontSize: '1.1rem' }}>{t('{0} sets · {1} work', setsDone(w), workSetsDone(w))}</div></div>
       <div className="tile"><div className="l">{t('PRs')}</div><div className="v" style={{ fontSize: 20 }}>{prs.length || '—'}</div></div>
     </div>
     {(prs.length > 0 || e1prs.length > 0) && <div style={{ textAlign: 'left', marginBottom: 12 }}>

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -186,9 +186,11 @@ function ActiveWorkout() {
     // Changing a weight cascades to the following sets of the same phase, so a
     // heavier bar carries through the set instead of retyping every row.
     if (field === 'w') {
+      const cfg = e.target || e
+      if (cfg.weightPrescription?.kind === 'percentage') return
       const warm = !!e.sets[i].warmup
       for (let j = i + 1; j < e.sets.length; j++) {
-        if (!!e.sets[j].warmup === warm) {
+        if (!!e.sets[j].warmup === warm && !e.sets[j].done) {
           if (v == null) delete e.sets[j][field]; else e.sets[j][field] = v
         }
       }

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -54,7 +54,7 @@ function Elapsed({ start }) {
 }
 
 /* ---------- one exercise block (reps: weight×reps · time: a held duration · cardio: duration+speed) ---------- */
-function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemoveSet, onStartTimed }) {
+function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemoveSet, onAddWarmup, onRemoveSetAt, onStartTimed }) {
   const S = useStore(s => s.S)
   const working = useUI(s => s.work)
   const entry = S.active.entries[entryIdx]
@@ -131,19 +131,30 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
     <div className="card" style={{ marginTop: 10, marginBottom: 0 }}>
       {/* the header carries the same eff3 sizing as the rows, or the labels drift off their columns */}
       <div className={'sethead' + (col3 ? ' eff3' : '')}><span className="n-sp" /><span className="w-sp">{col1.hd}</span>{col2 && <span className="r-sp">{col2.hd}</span>}{col3 && <span className="eff-sp">{col3.hd}</span>}{timed && <span className="ck-sp" />}<span className="ck-sp" /></div>
-      {entry.sets.map((s, i) => <div key={i} className={'setrow' + (s.done ? ' done' : '') + (col3 ? ' eff3' : '')}>
-        <div className="n">{i + 1}</div>
-        {cell(s, i, col1, 'w')}
-        {col2 && cell(s, i, col2, 'r')}
-        {col3 && cell(s, i, col3, 'eff')}
-        {/* A timed set is started, not typed: the timer counts the hold down and checks the
-            set off itself. The checkbox stays for anyone who timed it on their own watch. */}
-        {timed && <button className="setgo" aria-label={t('Start set')} disabled={s.done || !!working}
-          onClick={() => onStartTimed(i)}><Icon name="play" /></button>}
-        <Check checked={s.done} onChange={() => onToggle(i)} />
-      </div>)}
+      {entry.sets.map((s, i) => {
+        const warmBefore = i > 0 && !!entry.sets[i - 1].warmup
+        const isFirstWarmup = !!s.warmup && !warmBefore
+        return <div key={i}>
+          {isFirstWarmup && <div className="setph">{t('Warm-up')}</div>}
+          {!s.warmup && warmBefore && <div className="setsep" />}
+          <div className={'setrow' + (s.done ? ' done' : '') + (col3 ? ' eff3' : '')}>
+            <div className="n">{i + 1}</div>
+            {cell(s, i, col1, 'w')}
+            {col2 && cell(s, i, col2, 'r')}
+            {col3 && cell(s, i, col3, 'eff')}
+            {/* A timed set is started, not typed: the timer counts the hold down and checks the
+                set off itself. The checkbox stays for anyone who timed it on their own watch. */}
+            {timed && <button className="setgo" aria-label={t('Start set')} disabled={s.done || !!working}
+              onClick={() => onStartTimed(i)}><Icon name="play" /></button>}
+            {s.warmup && <button className="iconbtn" style={{ fontSize: 13 }} aria-label={t('Remove set')}
+              disabled={entry.sets.length <= 1} onClick={() => onRemoveSetAt(i)}><Icon name="xmark" /></button>}
+            <Check checked={s.done} onChange={() => onToggle(i)} />
+          </div>
+        </div>
+      })}
       <div style={{ height: 8 }} />
-      <div className="row">
+      <div className="row" style={{ flexWrap: 'wrap' }}>
+        <Button size="sm" icon="flame" onClick={onAddWarmup}>{t('Add warm-up set')}</Button>
         <Button size="sm" icon="minus" disabled={entry.sets.length <= 1} onClick={onRemoveSet}>{t('Remove set')}</Button>
         <Button size="sm" icon="plus" onClick={onAddSet}>{t('Add set')}</Button>
       </div>
@@ -172,6 +183,16 @@ function ActiveWorkout() {
   // what was actually logged — in the session, in history and in a backup.
   const setField = (idx, i, field, v) => mutEntry(idx, e => {
     if (v == null) delete e.sets[i][field]; else e.sets[i][field] = v
+    // Changing a weight cascades to the following sets of the same phase, so a
+    // heavier bar carries through the set instead of retyping every row.
+    if (field === 'w') {
+      const warm = !!e.sets[i].warmup
+      for (let j = i + 1; j < e.sets.length; j++) {
+        if (!!e.sets[j].warmup === warm) {
+          if (v == null) delete e.sets[j][field]; else e.sets[j][field] = v
+        }
+      }
+    }
   })
   const modeAt = idx => modeOf({ ...(A.entries[idx].target || {}), id: A.entries[idx].id })
   const addSet = idx => mutEntry(idx, e => {
@@ -182,6 +203,19 @@ function ActiveWorkout() {
     else e.sets.push({ w: l ? l.w : 0, r: l ? l.r : e.target.reps, done: false })
   })
   const removeSet = idx => mutEntry(idx, e => { if (e.sets.length > 1) e.sets.pop() })
+  const addWarmup = idx => mutEntry(idx, e => {
+    const firstWork = e.sets.findIndex(x => !x.warmup)
+    const at = firstWork === -1 ? e.sets.length : firstWork
+    const l = e.sets[at - 1] || e.sets[e.sets.length - 1]
+    const m = modeOf({ ...(e.target || {}), id: e.id })
+    const warm = m === 'cardio'
+      ? { min: l ? l.min : (e.target.min || 20), speed: l ? l.speed : (e.target.speed || 8), done: false, warmup: true }
+      : m === 'time'
+        ? { sec: l ? l.sec : (e.target.sec || 45), w: l ? (l.w || 0) : (e.target.weight || 0), done: false, warmup: true }
+        : { w: l ? l.w : 0, r: l ? l.r : e.target.reps, done: false, warmup: true }
+    e.sets.splice(at, 0, warm)
+  })
+  const removeSetAt = (idx, i) => mutEntry(idx, e => { if (e.sets.length > 1) e.sets.splice(i, 1) })
 
   // A timed set is held, not typed. The work timer records what was actually held — an early
   // finish logs 0:38 of a 0:45 target rather than crediting the full prescription — and then
@@ -267,11 +301,11 @@ function ActiveWorkout() {
           {unit.map((idx, k) => <div key={idx} className="ss-ex">
             {k > 0 && <div className="ss-amp">+</div>}
             <ExerciseBlock entryIdx={idx} compact
-              onToggle={i => toggle(idx, i)} onField={(i, f, v) => setField(idx, i, f, v)} onAddSet={() => addSet(idx)} onRemoveSet={() => removeSet(idx)} onStartTimed={i => startTimed(idx, i)} />
+              onToggle={i => toggle(idx, i)} onField={(i, f, v) => setField(idx, i, f, v)} onAddSet={() => addSet(idx)} onRemoveSet={() => removeSet(idx)} onAddWarmup={() => addWarmup(idx)} onRemoveSetAt={i => removeSetAt(idx, i)} onStartTimed={i => startTimed(idx, i)} />
           </div>)}
         </div>
       ) : (
-        <ExerciseBlock entryIdx={cur} onToggle={i => toggle(cur, i)} onField={(i, f, v) => setField(cur, i, f, v)} onAddSet={() => addSet(cur)} onRemoveSet={() => removeSet(cur)} onStartTimed={i => startTimed(cur, i)} />
+        <ExerciseBlock entryIdx={cur} onToggle={i => toggle(cur, i)} onField={(i, f, v) => setField(cur, i, f, v)} onAddSet={() => addSet(cur)} onRemoveSet={() => removeSet(cur)} onAddWarmup={() => addWarmup(cur)} onRemoveSetAt={i => removeSetAt(cur, i)} onStartTimed={i => startTimed(cur, i)} />
       )}
     </> : <div className="empty"><div className="ico"><Icon name="shuffle" /></div>{t('Freestyle workout — add your first exercise.')}</div>}
 

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
 import { useUI } from '../store/useUI.js'
 import { exOr } from '../lib/exercises.js'
-import { effectiveRoutine, lastEntryFor, bestWeightFor, buildSets, freestyleConfig, defaultConfig, setsDoneActive, supersetUnits, unitOf, setLabel, modeOf, isBw, isPerSide, sideReps, repStep, EFFORT, effortOf, stepEffort, capEffort } from '../lib/history.js'
+import { effectiveRoutine, lastEntryFor, bestWeightFor, buildSets, freestyleConfig, defaultConfig, setsDoneActive, supersetUnits, unitOf, setLabel, modeOf, isBw, isPerSide, sideReps, repStep, EFFORT, effortOf, stepEffort, capEffort, cascadeWeight, insertWarmupRow, removeRowAt } from '../lib/history.js'
 import { fmtNum, fmtDate, todayISO, exCount, DAYN } from '../lib/format.js'
 import { beep, vibrate } from '../lib/sound.js'
 import { t } from '../lib/i18n.js'
@@ -186,14 +186,7 @@ function ActiveWorkout() {
     // Changing a weight cascades to the following sets of the same phase, so a
     // heavier bar carries through the set instead of retyping every row.
     if (field === 'w') {
-      const cfg = e.target || e
-      if (cfg.weightPrescription?.kind === 'percentage') return
-      const warm = !!e.sets[i].warmup
-      for (let j = i + 1; j < e.sets.length; j++) {
-        if (!!e.sets[j].warmup === warm && !e.sets[j].done) {
-          if (v == null) delete e.sets[j][field]; else e.sets[j][field] = v
-        }
-      }
+      e.sets = cascadeWeight(e.sets, i, v)
     }
   })
   const modeAt = idx => modeOf({ ...(A.entries[idx].target || {}), id: A.entries[idx].id })
@@ -206,18 +199,10 @@ function ActiveWorkout() {
   })
   const removeSet = idx => mutEntry(idx, e => { if (e.sets.length > 1) e.sets.pop() })
   const addWarmup = idx => mutEntry(idx, e => {
-    const firstWork = e.sets.findIndex(x => !x.warmup)
-    const at = firstWork === -1 ? e.sets.length : firstWork
-    const l = e.sets[at - 1] || e.sets[e.sets.length - 1]
     const m = modeOf({ ...(e.target || {}), id: e.id })
-    const warm = m === 'cardio'
-      ? { min: l ? l.min : (e.target.min || 20), speed: l ? l.speed : (e.target.speed || 8), done: false, warmup: true }
-      : m === 'time'
-        ? { sec: l ? l.sec : (e.target.sec || 45), w: l ? (l.w || 0) : (e.target.weight || 0), done: false, warmup: true }
-        : { w: l ? l.w : 0, r: l ? l.r : e.target.reps, done: false, warmup: true }
-    e.sets.splice(at, 0, warm)
+    e.sets = insertWarmupRow(e.sets, m, e.target || {})
   })
-  const removeSetAt = (idx, i) => mutEntry(idx, e => { if (e.sets.length > 1) e.sets.splice(i, 1) })
+  const removeSetAt = (idx, i) => mutEntry(idx, e => { e.sets = removeRowAt(e.sets, i) })
 
   // A timed set is held, not typed. The work timer records what was actually held — an early
   // finish logs 0:38 of a 0:45 target rather than crediting the full prescription — and then

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -134,11 +134,13 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
       {entry.sets.map((s, i) => {
         const warmBefore = i > 0 && !!entry.sets[i - 1].warmup
         const isFirstWarmup = !!s.warmup && !warmBefore
+        // Numbering restarts per phase: with two warm-ups the first work set reads 1, not 3.
+        const phaseNum = entry.sets.slice(0, i + 1).filter(x => (x.warmup === true) === (s.warmup === true)).length
         return <div key={i}>
           {isFirstWarmup && <div className="setph">{t('Warm-up')}</div>}
           {!s.warmup && warmBefore && <div className="setsep" />}
           <div className={'setrow' + (s.done ? ' done' : '') + (col3 ? ' eff3' : '')}>
-            <div className="n">{i + 1}</div>
+            <div className="n">{phaseNum}</div>
             {cell(s, i, col1, 'w')}
             {col2 && cell(s, i, col2, 'r')}
             {col3 && cell(s, i, col3, 'eff')}


### PR DESCRIPTION
Three small session-screen improvements that came out of daily use:

- **Warm-up / work phase separation** - warm-up sets now render under their own "Warm-up" header with a divider before the work sets, so a session reads clearly in two phases.
- **Add / remove warm-up sets directly** - a new "Add warm-up set" button inserts before the first work set, and each warm-up row has its own remove button. The warmup flag is stored on the set and survives into history.
- **Weight cascade** - editing a set weight carries it forward to the following sets of the same phase, which saves retyping every row when you bump the bar.

All three are suggestions - happy to adjust wording, behaviour or scope. No linked issue exists for these (checked the open ones). Tests: 192/192 vitest, production build green, base 551b072c.