### PR TITLE
Freestyle sessions prefill from your last workout

### DIFF
--- a/frontend/src/lib/history.js
+++ b/frontend/src/lib/history.js
@@ -152,6 +152,21 @@ export function lastEntryFor(S, exId) {
   }
   return null
 }
+
+// A freestyle exercise starts with the last target the user actually trained, rather than the
+// generic config sheet defaults used when there is no history. The set rows themselves are still
+// built by buildSets(), which copies each completed set by position; only the target shape and
+// number of rows need to be seeded here so the config sheet and the rows agree.
+export function freestyleConfig(S, cfg) {
+  const last = lastEntryFor(S, cfg.id)
+  if (!last) return { ...cfg }
+  return {
+    ...cfg,
+    ...(last.target || {}),
+    id: cfg.id,
+    sets: Math.max(1, last.sets.length)
+  }
+}
 export function bestWeightFor(S, exId) {
   let best = 0
   S.workouts.forEach(w => w.entries.forEach(e => {
@@ -173,10 +188,11 @@ export function effectiveRoutine(S, iso) {
   const id = effectiveRoutineId(S, iso)
   return id ? S.routines.find(r => r.id === id) || null : null
 }
-export function buildSets(S, cfg) {
+export function buildSets(S, cfg, options = {}) {
   const last = lastEntryFor(S, cfg.id)
   const n = Math.max(1, cfg.sets || 1)
   const mode = modeOf(cfg)
+  const preferLast = !!options.preferLast
   const sets = []
   // Last time's set at the same position, falling back to its final set when the plan grew.
   const prevAt = i => (last ? (last.sets[i] || last.sets[last.sets.length - 1]) : null)
@@ -202,7 +218,9 @@ export function buildSets(S, cfg) {
   for (let i = 0; i < n; i++) {
     const prev = prevAt(i)
     const usable = prev && prev.r > 0 ? prev : null
-    const w = conf && conf.w > 0 ? conf.w : (usable ? usable.w : cfg.weight)
+    // Planned sessions may use the confirmed working weight, while freestyle should reproduce
+    // the load of each matching set when that option is requested.
+    const w = preferLast && usable ? usable.w : (conf && conf.w > 0 ? conf.w : (usable ? usable.w : cfg.weight))
     sets.push({ w, r: usable ? usable.r : cfg.reps, done: false })
   }
   return sets

--- a/frontend/src/lib/history.test.js
+++ b/frontend/src/lib/history.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { modeOf, isTimed, fmtSec, setLabel, defaultConfig, buildSets, exLine, workoutVolume, effortOf, stepEffort, capEffort, isBw, isPerSide, sideReps, repStep } from './history.js'
+import { modeOf, isTimed, fmtSec, setLabel, defaultConfig, buildSets, freestyleConfig, exLine, workoutVolume, effortOf, stepEffort, capEffort, isBw, isPerSide, sideReps, repStep } from './history.js'
 import { EXDB } from './exercises.js'
 
 // Real ids out of the shipped catalogue, so the body-part fallback is exercised for real.
@@ -336,6 +336,80 @@ describe('exLine', () => {
 
 const emptyS = { workouts: [], exWeights: {} }
 
+describe('freestyleConfig', () => {
+  it('inherits the last target and completed set count for a newly added exercise', () => {
+    const S = {
+      exWeights: {},
+      workouts: [{
+        d: '2026-01-01',
+        entries: [{
+          id: LIFT,
+          target: { mode: 'reps', sets: 4, reps: 8, weight: 60, prog: 'linear' },
+          sets: [
+            { w: 60, r: 8, done: true },
+            { w: 62.5, r: 7, done: true },
+            { w: 62.5, r: 6, done: true },
+            { w: 62.5, r: 5, done: true }
+          ]
+        }]
+      }]
+    }
+    const cfg = freestyleConfig(S, { id: LIFT, mode: 'reps', sets: 3, reps: 10, weight: 0 })
+
+    expect(cfg).toEqual({ id: LIFT, mode: 'reps', sets: 4, reps: 8, weight: 60, prog: 'linear' })
+    expect(buildSets(S, cfg)).toEqual([
+      { w: 60, r: 8, done: false },
+      { w: 62.5, r: 7, done: false },
+      { w: 62.5, r: 6, done: false },
+      { w: 62.5, r: 5, done: false }
+    ])
+  })
+
+  it('inherits the target for timed and cardio exercises too', () => {
+    const timed = {
+      exWeights: {},
+      workouts: [{
+        d: '2026-01-02',
+        entries: [{
+          id: LIFT,
+          target: { mode: 'time', sets: 2, sec: 60, weight: 15 },
+          sets: [{ sec: 55, w: 15, done: true }, { sec: 60, w: 17.5, done: true }]
+        }]
+      }]
+    }
+    const cardio = {
+      exWeights: {},
+      workouts: [{
+        d: '2026-01-03',
+        entries: [{
+          id: CARDIO,
+          target: { sets: 2, min: 30, speed: 7 },
+          sets: [{ min: 28, speed: 7, done: true }, { min: 30, speed: 7.5, done: true }]
+        }]
+      }]
+    }
+
+    const timedCfg = freestyleConfig(timed, { id: LIFT, mode: 'time', sets: 3, sec: 45, weight: 0 })
+    expect(timedCfg).toEqual({ id: LIFT, mode: 'time', sets: 2, sec: 60, weight: 15 })
+    expect(buildSets(timed, timedCfg)).toEqual([
+      { sec: 55, w: 15, done: false },
+      { sec: 60, w: 17.5, done: false }
+    ])
+
+    const cardioCfg = freestyleConfig(cardio, { id: CARDIO, sets: 1, min: 20, speed: 8 })
+    expect(cardioCfg).toEqual({ id: CARDIO, sets: 2, min: 30, speed: 7 })
+    expect(buildSets(cardio, cardioCfg)).toEqual([
+      { min: 28, speed: 7, done: false },
+      { min: 30, speed: 7.5, done: false }
+    ])
+  })
+
+  it('keeps the supplied defaults when there is no completed matching workout', () => {
+    const cfg = freestyleConfig(emptyS, { id: LIFT, mode: 'reps', sets: 3, reps: 10, weight: 50 })
+    expect(cfg).toEqual({ id: LIFT, mode: 'reps', sets: 3, reps: 10, weight: 50 })
+  })
+})
+
 describe('buildSets', () => {
   it('builds reps sets from the plan when there is no history', () => {
     expect(buildSets(emptyS, { id: LIFT, sets: 3, reps: 8, weight: 50 }))
@@ -373,6 +447,14 @@ describe('buildSets', () => {
   it('still prefers the confirmed working weight for reps sets', () => {
     const S = { exWeights: { [LIFT]: { w: 75 } }, workouts: [{ d: '2026-01-01', entries: [{ id: LIFT, sets: [{ w: 60, r: 10, done: true }] }] }] }
     expect(buildSets(S, { id: LIFT, sets: 1, reps: 8, weight: 50 })).toEqual([{ w: 75, r: 10, done: false }])
+  })
+
+  it('can preserve each last set weight for freestyle instead of using the working-weight hint', () => {
+    const S = { exWeights: { [LIFT]: { w: 75 } }, workouts: [{ d: '2026-01-01', entries: [{ id: LIFT, sets: [
+      { w: 60, r: 10, done: true }, { w: 62.5, r: 8, done: true }
+    ] }] }] }
+    expect(buildSets(S, { id: LIFT, sets: 2, reps: 8, weight: 50 }, { preferLast: true }))
+      .toEqual([{ w: 60, r: 10, done: false }, { w: 62.5, r: 8, done: false }])
   })
 })
 

--- a/frontend/src/sheets.jsx
+++ b/frontend/src/sheets.jsx
@@ -482,10 +482,10 @@ function ProgressionFields({ ex, mode, c, setC, routine, unit }) {
   </>
 }
 
-function ExConfig({ ex, existing, onSave, onDelete, close, routine }) {
+function ExConfig({ ex, existing, onSave, onDelete, close, routine, initial }) {
   const st = useStore(s => s.S)
   const cardio = isCardio(ex.id)
-  const [c, setC] = useState(existing || defaultConfig(ex.id))
+  const [c, setC] = useState(existing || initial || defaultConfig(ex.id))
   // Cardio keeps its own duration+speed form; the reps/time choice (issue #16) is offered for
   // everything else, which is where the gap was — planks, hangs, wall sits, loaded carries.
   const mode = cardio ? 'cardio' : modeOf({ ...c, id: ex.id })
@@ -596,7 +596,7 @@ function ExConfig({ ex, existing, onSave, onDelete, close, routine }) {
     {onDelete && <><div style={{ height: 8 }} /><Button variant="danger" onClick={() => { close(); onDelete() }}>{t('Remove from routine')}</Button></>}
   </>
 }
-export const exConfigSheet = (ex, existing, onSave, onDelete, routine) => ui().openSheet(close => <ExConfig ex={ex} existing={existing} onSave={onSave} onDelete={onDelete} routine={routine} close={close} />)
+export const exConfigSheet = (ex, existing, onSave, onDelete, routine, initial) => ui().openSheet(close => <ExConfig ex={ex} existing={existing} initial={initial} onSave={onSave} onDelete={onDelete} routine={routine} close={close} />)
 
 /* ============================ glyph picker ============================ */
 // Grouped by what the glyph means for a training day, so picking one is a scan

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
 import { useUI } from '../store/useUI.js'
 import { exOr } from '../lib/exercises.js'
-import { effectiveRoutine, lastEntryFor, bestWeightFor, buildSets, setsDoneActive, supersetUnits, unitOf, setLabel, modeOf, isBw, isPerSide, sideReps, repStep, EFFORT, effortOf, stepEffort, capEffort } from '../lib/history.js'
+import { effectiveRoutine, lastEntryFor, bestWeightFor, buildSets, freestyleConfig, defaultConfig, setsDoneActive, supersetUnits, unitOf, setLabel, modeOf, isBw, isPerSide, sideReps, repStep, EFFORT, effortOf, stepEffort, capEffort } from '../lib/history.js'
 import { fmtNum, fmtDate, todayISO, exCount, DAYN } from '../lib/format.js'
 import { beep, vibrate } from '../lib/sound.js'
 import { t } from '../lib/i18n.js'
@@ -281,12 +281,20 @@ function ActiveWorkout() {
       <Button trailingIcon="chevronRight" disabled={unitIdx < 0 || unitIdx >= units.length - 1} onClick={() => update(s => { s.active.cur = units[unitIdx + 1][0] })}>{t('Next')}</Button>
     </div>
     <div style={{ height: 10 }} />
-    <Button onClick={() => exercisePicker(ex => exConfigSheet(ex, null, cfg => update(s => {
-      const full = { ...cfg, id: ex.id }
-      const plan = nextPrescription(s, full, s.routines.find(r => r.id === s.active.routineId))
-      s.active.entries.push({ id: ex.id, target: { ...cfg }, plan, sets: applyPrescription(buildSets(s, full), plan) })
-      s.active.cur = s.active.entries.length - 1
-    }), null, S.routines.find(r => r.id === A.routineId)))} icon="plus">{t('Add exercise')}</Button>
+    <Button onClick={() => exercisePicker(ex => {
+      const routine = S.routines.find(r => r.id === A.routineId)
+      const freestyle = !A.routineId
+      // Freestyle has no routine prescription to apply: show the last target in the config
+      // sheet and carry its completed rows forward. A planned session keeps its existing path.
+      const seed = freestyle ? freestyleConfig(S, { id: ex.id, ...defaultConfig(ex.id) }) : null
+      exConfigSheet(ex, null, cfg => update(s => {
+        const full = { ...cfg, id: ex.id }
+        const plan = freestyle ? null : nextPrescription(s, full, s.routines.find(r => r.id === s.active.routineId))
+        const sets = buildSets(s, full, freestyle ? { preferLast: true } : undefined)
+        s.active.entries.push({ id: ex.id, target: { ...cfg }, plan, sets: freestyle ? sets : applyPrescription(sets, plan) })
+        s.active.cur = s.active.entries.length - 1
+      }), null, routine, seed)
+    })} icon="plus">{t('Add exercise')}</Button>
     <div style={{ height: 10 }} />
     {(() => {
       const exDone = A.entries.filter(e => e.sets.length && e.sets.every(s => s.done)).length


### PR DESCRIPTION
Small quality-of-life change: when you add an exercise to a freestyle (empty) workout, its sets are pre-filled from your last logged session of that exercise - same sets, reps and weight (or duration/speed for cardio, seconds for holds) - so the session starts from where you left off instead of from blanks.

Routine-driven sessions keep the existing progression logic untouched.

A suggestion - happy to adjust wording, behaviour or scope. Tests: 196/196 vitest (4 new for the prefill helper), production build green, base 551b072c.