### PR TITLE
Coach: a way in, and instructions for getting there

### DIFF
--- a/docs/AI_COACH.md
+++ b/docs/AI_COACH.md
@@ -3,11 +3,55 @@
 An optional AI that **designs** a training plan and **revises it from what you actually log**,
 running on your own server under your own provider account, off until an admin turns it on.
 
-> This document grows with the feature. What is described here is what has landed: the server
-> plumbing, the consent and payload boundary, the credential model, the validator and apply
-> path, and the Claude provider with its opt-in packaging. The UI arrives in the PRs that follow.
+> This document grows with the feature, which lands across a sequence of PRs. Anything described
+> here that has not reached your instance yet is visibly absent rather than broken — the Coach
+> only appears at all once an admin has enabled it and a runtime can be reached.
 
 ---
+
+## Turning it on
+
+Nothing here is an environment variable or a restart — the whole point of the admin card is that
+enabling the Coach is a decision you make in the app.
+
+**1. Build the image that has an AI runtime in it.** The default image deliberately has none:
+
+```bash
+API_TARGET=coach docker compose up -d --build api
+```
+
+`--build` matters. With a prebuilt `image:` also set, compose would otherwise pull the default.
+
+**2. Get a credential.** On a trusted machine where you already use Claude Code:
+
+```bash
+claude setup-token
+```
+
+Complete its normal browser sign-in and copy the token it prints. openGym never opens or handles
+that flow — it only ever receives the finished token.
+
+**3. Connect it.** In the app: **Settings → Admin → AI Coach**.
+
+- Toggle the card on.
+- Pick the **Claude (Anthropic)** provider chip.
+- **Add CLI token** → paste the token, and optionally label whose account it is (that label is
+  what both the admin card and each user's Coach screen show when they name the account).
+- **Test the Coach** — a real round trip through the provider with no user data anywhere near it.
+  It reports the runtime version on success, and the provider's own error on failure.
+
+The card also states two things worth reading before anyone uses it: whether jobs actually run
+unprivileged, and which account is being spent.
+
+**4. Use it.** Each person opens **Plan → AI Coach**, agrees to the consent screen — which lists
+exactly what leaves the server, generated from the same module that builds payloads — and then
+either has a plan built from a short intake or asks for a review of what they have logged.
+
+> **On a multi-profile instance, read [Whose account pays](#whose-account-pays) first.** In the
+> default instance mode the credential binds to the first profile that spends it and **every
+> other profile is refused**, by design. That is the right behaviour when one person's personal
+> subscription is behind it — but on a shared box it means one user gets the Coach and the rest
+> get a refusal until per-profile sign-in exists.
 
 ## Whose account pays
 

--- a/frontend/src/views/Plan.jsx
+++ b/frontend/src/views/Plan.jsx
@@ -4,13 +4,24 @@ import { DAYN, uid, exCount } from '../lib/format.js'
 import { t } from '../lib/i18n.js'
 import { dayAssignSheet, loadStarterPlan, planToolsSheet } from '../sheets.jsx'
 import Icon from '../components/Icon.jsx'
-import { Button } from '../components/ui.jsx'
+import { Button, Row } from '../components/ui.jsx'
 import { glyphOf, DEFAULT_GLYPH } from '../lib/glyphs.js'
+import { DEMO } from '../lib/demo.js'
+import { MOBILE } from '../lib/mobile.js'
+import { coachAvailable } from '../lib/coach.js'
 
 export default function Plan() {
   const nav = useNavigate()
   const S = useStore(s => s.S)
   const update = useStore(s => s.update)
+  const config = useStore(s => s.config)
+  const user = useStore(s => s.user)
+
+  /* The Coach's only entry point in the app. Its screens have existed since the UI landed and
+     nothing linked to them, so the feature was reachable only by typing the URL — enabled,
+     configured, and invisible. The same predicate every other Coach surface uses gates it, so
+     an instance without the feature sees exactly the Plan screen it saw before. */
+  const showCoach = coachAvailable(config, user, { demo: DEMO, mobile: MOBILE })
 
   const addRoutine = () => {
     const r = { id: uid(), name: t('New routine'), emoji: DEFAULT_GLYPH, ex: [] }
@@ -23,6 +34,13 @@ export default function Plan() {
       <div><h1>{t('Plan')}</h1><div className="sub">{t('Your weekly routine')}</div></div>
       <button className="iconbtn" onClick={planToolsSheet} aria-label={t('Share your plan')} title={t('Share your plan')}><Icon name="upload" /></button>
     </div>
+    {showCoach && <div className="list" style={{ marginBottom: 10 }}>
+      <Row icon="sparkles" iconTint="var(--acc)" accessory="chevron"
+        title={t('AI Coach')}
+        subtitle={t('Build a plan, or have it reviewed against what you actually logged.')}
+        onClick={() => nav('/coach')} />
+    </div>}
+
     <div className="cols"><div>
       <h4 className="sec">{t('Week schedule')}</h4>
       <div className="list" style={{ display: 'flex', flexDirection: 'column' }}>


### PR DESCRIPTION
Two gaps I found the only way you reliably find this kind of thing — by deploying it to a real instance and then trying to use it. Branched from `coach` and depends on neither open PR.

## The Coach had no entry point

`/coach`, `/coach/intake` and `/coach/proposal` have existed since the UI landed, and **nothing in the app linked to any of them.** Not the nav bar, not Home, not Plan, not Settings — the only file in the frontend that mentions `/coach` outside the Coach views themselves is `App.jsx`, where the routes are declared.

The hub's back button already navigates to `/plan`, so that is where the link was always meant to be; it just never got added.

On my instance that meant the feature was enabled, credentialed, the runtime live, a real round trip through the provider passing — and reachable only by typing the URL into the address bar.

It is a single `Row` on the Plan screen, behind the same `coachAvailable()` predicate every other Coach surface uses, so an instance without the feature renders exactly the Plan screen it rendered before.

## And no instructions for setting it up

`docs/AI_COACH.md` said the Coach is *"off until an admin turns it on"* — and then never said how to turn it on. Ten sections on what it does and why it is safe; nothing on the four steps between a running instance and a working Coach. `.env.example` has no Coach knobs and `SELF_HOSTING.md` mentions it only in the backup caveat, so there was nowhere else to look.

The new **Turning it on** section covers:

1. Building the target that actually has a runtime in it (`API_TARGET=coach docker compose up -d --build api`, and why `--build` matters when an `image:` is also set)
2. Minting a token with `claude setup-token` on a trusted machine — openGym never opens or handles that flow, it only receives the finished token
3. Connecting and testing it on the admin card
4. Where a user starts, and what the consent screen shows them

It also warns up front about the thing a multi-profile instance otherwise discovers the hard way: **in instance mode the credential binds to the first profile that spends it and every other profile is refused**, by design. That is right when one person's personal subscription is behind it, but on a shared box it means one user gets the Coach and everyone else gets the refusal message until per-profile sign-in exists.

## Verified

api **72/72**, frontend **404/404**, build clean, 11 locales in sync at 628.

Both changes came out of running the full stack on a real box: five profiles, the Claude provider connected, `canDropPrivileges()` reporting `dropped: true`, and `jobs.testRun()` completing a genuine round trip through the Agent SDK. Everything worked — there was just no way for anyone to get to it, and no page that told them how.