### PR TITLE
Import: stamp the profile unit on every positive weighted set from unit-less files

### DIFF
--- a/frontend/src/lib/import-csv.js
+++ b/frontend/src/lib/import-csv.js
@@ -404,7 +404,15 @@ export function parseWorkoutCSV(text, { unit = 'kg' } = {}) {
   const workouts = dates.map(d => {
     const day = byDate.get(d)
     const entries = [...day.ex.entries()].map(([id, ss]) => {
-      const conv2 = ss.map(({ u, ...s }) => (s.w !== undefined ? { ...s, w: convRow({ ...s, u }) } : s))
+      const conv2 = ss.map(({ u, ...s }) => {
+        if (s.w === undefined) return s
+        const convertedSet = { ...s, w: convRow({ ...s, u }) }
+        // A row without its own unit follows the file's, and a file that says nothing
+        // is taken to already be in the profile's unit - so every positive weighted set
+        // must carry the stamp: unit-aware consumers (history, stats, the model) rely
+        // on a weighted set always being resolvable to its unit.
+        return s.w > 0 ? { ...convertedSet, unit } : convertedSet
+      })
       const mx = Math.max(0, ...conv2.map(s => s.w || 0))
       return { id, sets: conv2, topW: mx || null }
     })

--- a/frontend/src/lib/import-csv.test.js
+++ b/frontend/src/lib/import-csv.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { parseWorkoutCSV } from './import-csv.js'
+
+// Headers as the real exports write them, trimmed to the columns that matter here.
+const FITNOTES = 'Date,Exercise,Category,Weight,Reps,Distance,Distance Unit,Time'
+const rows = (head, ...lines) => parseWorkoutCSV([head, ...lines].join('\n'), { unit: 'kg' })
+const setsOf = p => p.workouts.flatMap(w => w.entries.flatMap(e => e.sets))
+
+describe('unit stamping for unit-less files', () => {
+  it('stamps the profile unit on every positive weighted set', () => {
+    // The classic FitNotes shape: no unit column. The file is taken to be in the
+    // profile's unit, and every positive weighted set still carries the stamp so the
+    // record stays compatible with unit-aware consumers (history, stats, the model).
+    const p = rows(FITNOTES,
+      '2026-01-12,Bench Press,Chest,60,10,,,',
+      '2026-01-12,Bench Press,Chest,50,8,,,')
+    expect(p.error).toBeUndefined()
+    const sets = setsOf(p)
+    expect(sets).toHaveLength(2)
+    expect(sets.every(s => s.w > 0 && s.unit === 'kg')).toBe(true)
+  })
+
+  it('stamps the profile unit after converting a row that disagrees', () => {
+    // A lb row in a kg profile is converted, and the stamp reflects the conversion
+    // rather than the source unit, so the stored value and its unit always agree.
+    const head = 'Date,Exercise,Category,Weight,Weight Unit,Reps'
+    const p = rows(head,
+      '2026-01-12,Bench Press,Chest,135,lb,10')
+    expect(p.error).toBeUndefined()
+    const sets = setsOf(p)
+    expect(sets).toHaveLength(1)
+    expect(sets[0].w).toBeCloseTo(61.2, 1)
+    expect(sets[0].unit).toBe('kg')
+  })
+})

--- a/frontend/src/lib/import-effort.test.js
+++ b/frontend/src/lib/import-effort.test.js
@@ -93,7 +93,8 @@ describe('importing effort from another app', () => {
   it('leaves a file without any rating column exactly as it was', () => {
     const p = rows(FITNOTES, '2026-01-12,Bench Press,Chest,60,10,,,')
     const s = setsOf(p)[0]
-    expect(s).toEqual({ w: 60, r: 10, done: true })
+    // the legacy profile-unit path now stamps the resolved unit so the record stays compatible
+    expect(s).toEqual({ w: 60, r: 10, done: true, unit: 'kg' })
     expect(p.rpeSets + p.rirSets).toBe(0)
   })
 


### PR DESCRIPTION
**What.** When a CSV has no unit column at all — the classic FitNotes/Strong export shape — the import assumed the profile unit but never wrote that assumption down: every positive weighted set stayed unit-less in the stored record.

**Why it matters.** A stored weight without a unit is ambiguous, and any unit-aware consumer (history, stats, future unit handling) has to either guess or reject the record. Unit-less exports from those apps are very common, so this shows up in daily use.

**The fix.** In the import conversion pass, every positive weighted set now carries the profile unit it was stored in. Rows that carry their own unit still convert per row as before (lb → kg etc.); the stamp always reflects the final stored value, so the weight and its unit can never disagree.

**Verified.** 230/230 tests pass, including new coverage for the unit-less FitNotes shape and for a lb row imported into a kg profile; the production build is clean.

I checked for an existing issue covering this and didn't find one. Happy to adjust wording, behaviour or scope.
