### PR TITLE
Coach: the store field the whole UI reads, which was never ported

### DIFF
--- a/frontend/src/lib/coach.test.js
+++ b/frontend/src/lib/coach.test.js
@@ -443,3 +443,26 @@ describe('validation', () => {
     expect(validateProposal({ changes: [change()] })).toBe(true)
   })
 })
+
+describe('the gate has something real to read', () => {
+  it('the store actually exposes the `config` field every Coach entry point reads', async () => {
+    // coachAvailable(config, …) is false when `config` is undefined, which is indistinguishable
+    // from "this instance has no Coach". The views were ported once without the store field they
+    // depend on, so every Coach surface silently vanished on every instance: no entry point, and
+    // /#/coach redirecting straight back to /home. A missing key must fail here, not in a browser.
+    // Asserted against the source rather than the live store: useStore touches `document` at
+    // import time, so it cannot be instantiated in this environment. Crude, but it fails on
+    // exactly the two edits that broke it — dropping the field, or dropping the fetch.
+    const { readFileSync } = await import('node:fs')
+    const src = readFileSync(new URL('../store/useStore.js', import.meta.url), 'utf8')
+    expect(src).toMatch(/\bconfig:\s*null\b/)
+    expect(src).toMatch(/set\(\s*\{\s*config:\s*await api\(['"]\/api\/config['"]\)/)
+  })
+
+  it('a configured instance with a signed-in user opens the gate', () => {
+    // The exact shape GET /api/config returns when the Coach is on.
+    const config = { invite_only: false, coach: { enabled: true, provider: 'claude', authMode: 'instance' } }
+    expect(coachAvailable(config, { id: 'u' })).toBe(true)
+    expect(coachAvailable(undefined, { id: 'u' })).toBe(false)   // the bug, pinned
+  })
+})

--- a/frontend/src/store/useStore.js
+++ b/frontend/src/store/useStore.js
@@ -83,6 +83,11 @@ export const useStore = create((set, get) => {
     S: (() => { const s = loadState(); registerCustom(s.customEx); return s })(),
     user: (() => { try { return JSON.parse(localStorage.getItem('gym_user')) || null } catch { return null } })(),
     ready: false,
+    /* Instance capabilities from GET /api/config. `config.coach` is present only when the owner
+       has both enabled the Coach and connected a provider — every Coach entry point in the app
+       hangs off it via coachAvailable(), so an unconfigured instance renders exactly what it
+       always did, and a configured one is the only place any of it appears. */
+    config: null,
 
     // Mutate a draft of S via producer fn, then persist + schedule sync.
     update(mut, push = true) {
@@ -172,6 +177,9 @@ export const useStore = create((set, get) => {
         set({ ready: true })
         return
       }
+      // Instance capabilities are public and are needed whether or not anyone is signed in —
+      // fetched before /api/me so the first render already knows what this instance offers.
+      try { set({ config: await api('/api/config') }) } catch { /* offline — assume nothing extra */ }
       try {
         const me = await api('/api/me')
         get().setUser(me.user)


### PR DESCRIPTION
Follow-up to [#54](https://github.com/DuarteSantos8/openGym/pull/54) — it merged while I was pushing this, so the entry point landed without the thing that makes it work.

## The bug

Every Coach surface gates on `coachAvailable(config, user)`. `config` comes from `useStore(s => s.config)`. **That field does not exist.** 4/6 ported the views and left behind the one line of store they all depend on.

So `config` is `undefined` at all five call sites, the gate is `false` on every instance, and the feature is invisible everywhere:

- no AI Coach row on Plan, even with the entry point from #54
- `/#/coach` redirects straight back to `/home`
- the consent screen is unreachable, so nothing downstream of it exists either

I found it on a real deployment where the Coach was enabled, credentialed, `canDropPrivileges()` reporting `dropped: true`, and `jobs.testRun()` completing a genuine round trip through the Agent SDK. Every server-side check passed. There was simply no way in.

**It survived review because the failure mode is silence.** An undefined `config` is indistinguishable from "this instance has no Coach" — which is the correct, intended behaviour for most instances, and therefore looks like nothing is wrong. Nothing throws, nothing logs, the build is clean and the tests pass.

## The fix

`config: null` on the store, plus the boot-time fetch — placed ahead of `/api/me`, since instance capabilities are public and are needed whether or not anyone is signed in.

## Tests

Two, aimed squarely at how this got through:

- the gate opens for the exact shape `GET /api/config` returns, and stays shut for `undefined` — the bug itself, pinned
- the store source still declares the field and still performs the fetch. That one reads the file rather than the live store, because `useStore` touches `document` at import time and cannot be instantiated in the test environment. Crude, but it fails on precisely the two edits that broke this.

frontend **406/406**, build clean.

Worth saying plainly: this was mine, in a PR you'd already merged, and no test or CI job we have could have caught it. The UI compiled, the suite was green, and the server was right. It took deploying the thing and trying to use it.