### PR TITLE
Progression: guard set growth against an all-warm-up entry (follow-up to #48)

### DIFF
--- a/frontend/src/lib/progression.js
+++ b/frontend/src/lib/progression.js
@@ -267,7 +267,10 @@ export function applyPrescription(sets, p) {
   // row that is already there: a session in progress must not lose a set it has logged.
   const workRows = out.filter(s => !s.warmup)
   if (p.sets > workRows.length) {
-    const seed = workRows[workRows.length - 1] || out[out.length - 1]
+    // An all-warm-up entry has no work row to seed growth from - growing warm-up copies
+    // would both invent work and never terminate the loop. Leave the entry untouched.
+    if (!workRows.length) return out
+    const seed = workRows[workRows.length - 1]
     while (out.filter(s => !s.warmup).length < p.sets) out.push({ ...seed, done: false })
   }
   return out

--- a/frontend/src/lib/progression.test.js
+++ b/frontend/src/lib/progression.test.js
@@ -502,4 +502,13 @@ describe('applyPrescription never touches warm-up rows (round 3)', () => {
     expect(out.filter(s => s.warmup)).toHaveLength(1)  // warm-up untouched
     expect(out[0]).toEqual({ w: 20, r: 8, done: true, warmup: true })
   })
+
+  it('an all-warm-up entry terminates and stays untouched', () => {
+    const sets = [
+      { w: 20, r: 8, done: true, warmup: true },
+      { w: 25, r: 6, done: true, warmup: true },
+    ]
+    const out = applyPrescription(sets, { kind: 'up', weight: 62.5, reps: 5, sets: 4 })
+    expect(out).toEqual(sets) // no work row to seed growth from - nothing grows, no loop
+  })
 })


### PR DESCRIPTION
Small follow-up to #48 (just merged): the set-growth loop's seed falls back to the last row when there are no work rows, and an all-warm-up entry (`[warm]` — reachable by adding a warm-up to a one-set exercise and removing the work row) would then copy a warm-up forever, never growing the work count.

Guard: when there are no work rows, the prescription leaves the entry untouched instead of seeding from a warm-up. 238/238 tests pass (new case pins the all-warm-up entry) and the production build is green.

Thanks again for the three rounds on #48.
