### PR TITLE
Canonical units step 1: pure conversion + migration helpers

### DIFF
--- a/frontend/src/lib/units.js
+++ b/frontend/src/lib/units.js
@@ -1,0 +1,146 @@
+// Pure helpers for the canonical weight representation.
+//
+// Persisted weights are kilograms. A profile's display unit is a boundary concern: callers use
+// kgFromStored when accepting a value in a profile/file unit and storedFromKg when rendering it.
+// This module deliberately has no React, store, or browser dependencies.
+
+export const CANONICAL_UNIT = 'kg'
+export const LB_TO_KG = 0.45359237
+export const KG_TO_LB = 1 / LB_TO_KG
+
+const UNIT_FIELDS = new Set(['unit', 'u', 'weightUnit', 'storedUnit', 'weight_unit', 'loadUnit'])
+const WEIGHT_FIELDS = new Set([
+  'w', 'weight', 'topW', 'fallbackWeight', 'resolvedWeight', 'inc',
+  'bw', 'workW', 'workWeight', 'workResolvedWeight', 'loadFallback', 'fallback'
+])
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function numeric(value) {
+  if (value === null || value === undefined || value === '' || typeof value === 'boolean') return null
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+function isPounds(unit) {
+  return /^(?:lb|lbs|pound|pounds)$/i.test(String(unit ?? '').trim())
+}
+
+/** Normalize the supported display/source spellings without making unknown values hazardous. */
+export function normalizeUnit(unit) {
+  return isPounds(unit) ? 'lb' : CANONICAL_UNIT
+}
+
+/** Convert a stored/display weight into canonical kilograms. Unknown units are treated as kg. */
+export function kgFromStored(value, unit = CANONICAL_UNIT) {
+  const n = numeric(value)
+  if (n === null) return value
+  return isPounds(unit) ? n * LB_TO_KG : n
+}
+
+/** Convert canonical kilograms to a profile/file unit without display rounding. */
+export function storedFromKg(value, unit = CANONICAL_UNIT) {
+  const n = numeric(value)
+  if (n === null) return value
+  return isPounds(unit) ? n / LB_TO_KG : n
+}
+
+/**
+ * Round a value for display controls before passing it to fmtNum.
+ *
+ * The app uses half-kilogram display increments and whole-pound increments. The larger 2.5 kg
+ * and 5 lb progression jumps are policy increments, not a reason to lose precision in display
+ * conversion.
+ */
+export function unitRound(value, unit = CANONICAL_UNIT) {
+  const n = numeric(value)
+  if (n === null) return value
+  const step = isPounds(unit) ? 1 : 0.5
+  return Math.round(n / step) * step
+}
+
+/** Bodyweight is already canonical after the state migration; the display unit is irrelevant. */
+export function kgBodyweight(bwKg, _unit) {
+  return bwKg
+}
+
+function unitOf(record, inheritedUnit) {
+  if (isRecord(record)) {
+    for (const key of UNIT_FIELDS) {
+      if (record[key] !== undefined && record[key] !== null && String(record[key]).trim() !== '') {
+        return record[key]
+      }
+    }
+  }
+  return inheritedUnit
+}
+
+function convertWeight(value, unit) {
+  return kgFromStored(value, unit)
+}
+
+function migrateNode(value, inheritedUnit = CANONICAL_UNIT) {
+  if (Array.isArray(value)) return value.map(item => migrateNode(item, inheritedUnit))
+  if (!isRecord(value)) return value
+
+  const localUnit = unitOf(value, inheritedUnit)
+  const out = {}
+  for (const [key, child] of Object.entries(value)) {
+    // Unit metadata is a one-time migration input, never a field we write into canonical state.
+    if (UNIT_FIELDS.has(key)) continue
+
+    if (key === 'vol') {
+      // Volume is recomputed from canonical rows below when possible. Keep a converted fallback
+      // for legacy records that only carried the derived number.
+      out[key] = numeric(child) === null ? child : convertWeight(child, localUnit)
+      continue
+    }
+
+    if (WEIGHT_FIELDS.has(key) && numeric(child) !== null) {
+      out[key] = convertWeight(child, localUnit)
+      continue
+    }
+
+    // A direct numeric `bodyweight` is a weigh-in; the boolean bodyweight flag is not a load.
+    if (key === 'bodyweight' && numeric(child) !== null) {
+      out[key] = convertWeight(child, localUnit)
+      continue
+    }
+
+    out[key] = migrateNode(child, localUnit)
+  }
+
+  if (Array.isArray(out.entries)) {
+    const rows = out.entries.flatMap(entry => Array.isArray(entry?.sets) ? entry.sets : [])
+    if (rows.length) {
+      out.vol = rows.reduce((total, set) => {
+        if (!set || set.done !== true) return total
+        const w = numeric(set.w)
+        const reps = numeric(set.r)
+        return w === null || reps === null ? total : total + w * reps
+      }, 0)
+    }
+  }
+
+  return out
+}
+
+/**
+ * Convert legacy workout records to canonical kilograms without mutating the input.
+ *
+ * Missing unit metadata is deliberately interpreted as kg: that is the representation used by
+ * every pre-canonical openGym profile. Existing unit metadata may live on a workout, entry, set,
+ * target, warm-up row, or weight prescription; it is consumed and removed. Therefore the result
+ * has no per-set unit stamps and running this function again is a no-op.
+ */
+export function migrateWorkoutsToKg(workouts) {
+  if (!Array.isArray(workouts)) return []
+  return workouts.map(workout => migrateNode(workout, CANONICAL_UNIT))
+}
+
+// Descriptive aliases are useful to boundary callers while the canonical names remain the
+// public contract for this slice.
+export const toKg = kgFromStored
+export const fromKg = storedFromKg

--- a/frontend/src/lib/units.test.js
+++ b/frontend/src/lib/units.test.js
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  kgFromStored,
+  storedFromKg,
+  unitRound,
+  migrateWorkoutsToKg,
+  kgBodyweight,
+} from './units.js'
+
+const LB_TO_KG = 0.45359237
+
+const legacyWorkouts = () => [{
+  id: 'workout-1',
+  unit: 'lb',
+  bw: 180,
+  bodyweight: [{ d: '2026-01-01', w: 180, unit: 'lb' }],
+  entries: [{
+    id: 'squat',
+    unit: 'lb',
+    topW: 200,
+    fallbackWeight: 150,
+    sets: [
+      { phase: 'warmup', w: 50 },
+      { phase: 'work', w: 200, r: 5, done: true },
+    ],
+    warmup: [{ unit: 'lb', w: 40, r: 8, done: true }],
+    target: {
+      unit: 'lb',
+      weight: 200,
+      weightPrescription: { unit: 'lb', fallbackWeight: 175 },
+      warmup: [{
+        unit: 'lb',
+        weight: 50,
+        weightPrescription: { unit: 'lb', fallbackWeight: 25 },
+      }],
+    },
+    plan: { unit: 'lb', weight: 180, fallbackWeight: 160 },
+  }],
+}]
+
+describe('canonical weight conversions', () => {
+  it('converts stored pounds to kilograms with the specified factor', () => {
+    expect(kgFromStored(100, 'lb')).toBe(100 * LB_TO_KG)
+    expect(kgFromStored(60, 'kg')).toBe(60)
+  })
+
+  it('round-trips kilograms through pounds without display rounding', () => {
+    const kg = 60
+    const stored = storedFromKg(kg, 'lb')
+    expect(kgFromStored(stored, 'lb')).toBeCloseTo(kg, 12)
+    expect(storedFromKg(kg, 'kg')).toBe(kg)
+  })
+
+  it('rounds display values to the profile unit precision', () => {
+    expect(unitRound(62.24, 'kg')).toBe(62)
+    expect(unitRound(62.26, 'kg')).toBe(62.5)
+    expect(unitRound(132.49, 'lb')).toBe(132)
+    expect(unitRound(132.5, 'lb')).toBe(133)
+  })
+
+  it('keeps an already-canonical bodyweight in kilograms', () => {
+    expect(kgBodyweight(72.5, 'kg')).toBe(72.5)
+    expect(kgBodyweight(72.5, 'lb')).toBe(72.5)
+  })
+})
+
+describe('workout migration', () => {
+  it('converts legacy pounds across workout, bodyweight, target, warm-up, and prescription fields', () => {
+    const source = legacyWorkouts()
+    const migrated = migrateWorkoutsToKg(source)
+    const workout = migrated[0]
+    const entry = workout.entries[0]
+
+    expect(workout.bw).toBe(180 * LB_TO_KG)
+    expect(workout.bodyweight[0].w).toBe(180 * LB_TO_KG)
+    expect(entry.topW).toBe(200 * LB_TO_KG)
+    expect(entry.fallbackWeight).toBe(150 * LB_TO_KG)
+    expect(entry.sets.map(set => set.w)).toEqual([50 * LB_TO_KG, 200 * LB_TO_KG])
+    expect(entry.warmup[0].w).toBe(40 * LB_TO_KG)
+    expect(entry.target.weight).toBe(200 * LB_TO_KG)
+    expect(entry.target.weightPrescription.fallbackWeight).toBe(175 * LB_TO_KG)
+    expect(entry.target.warmup[0].weight).toBe(50 * LB_TO_KG)
+    expect(entry.target.warmup[0].weightPrescription.fallbackWeight).toBe(25 * LB_TO_KG)
+    expect(entry.plan.weight).toBe(180 * LB_TO_KG)
+    expect(entry.plan.fallbackWeight).toBe(160 * LB_TO_KG)
+  })
+
+  it('returns a new array without mutating the source and is idempotent', () => {
+    const source = legacyWorkouts()
+    const migrated = migrateWorkoutsToKg(source)
+
+    expect(migrated).not.toBe(source)
+    expect(source[0].entries[0].sets[0].w).toBe(50)
+    expect(migrateWorkoutsToKg(migrated)).toEqual(migrated)
+  })
+
+  it('leaves unannotated kg-era values numerically unchanged and removes consumed stamps', () => {
+    const source = [{
+      unit: 'kg',
+      entries: [{
+        unit: 'kg',
+        sets: [{ w: 60, unit: 'kg', r: 5 }],
+        target: { unit: 'kg', weight: 60 },
+      }],
+    }]
+    const migrated = migrateWorkoutsToKg(source)
+
+    expect(migrated[0].entries[0].sets[0].w).toBe(60)
+    expect(migrated[0].entries[0].target.weight).toBe(60)
+    expect(migrated[0].unit).toBeUndefined()
+    expect(migrated[0].entries[0].unit).toBeUndefined()
+    expect(migrated[0].entries[0].sets[0].unit).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Canonical weight helpers - step 1 of the canonical-unit approach

This is the first, pure slice of the canonical-unit design discussed in PR #56: a small dependency-free module plus tests, with **no UI, store, or import wiring yet** - that comes in a follow-up.

What it adds:
- `kgFromStored` / `storedFromKg` - exact lb<->kg conversion (0.45359237) for the profile/file boundary
- `unitRound` - display rounding (0.5 kg / 1 lb steps), kept separate from progression policy
- `kgBodyweight` - identity helper so the Stats fatigue path stays correct once the toggle converts
- `migrateWorkoutsToKg` - idempotent, non-mutating migration of stored weights (sets, bodyweight rows, targets, warm-ups, plans, `fallbackWeight`) to canonical kg, honouring legacy unit fields without adding per-set stamps

Design notes:
- Persisted weights become kg; the display unit stays a boundary concern (no relabel-only behaviour)
- Unknown units are treated as kg (safe default for legacy data)
- Round-trips are exact (lb->kg->lb), and kg profiles see byte-identical values after migration

Verified: full frontend vitest suite 244/244 and `npm run build` green on the merged branch (fresh checkout).