### PR TITLE
Session supersets: pair or un-pair exercises directly in the workout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ frontend/dist/
 node_modules/
 *.log
 .DS_Store
+node_modules

--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,0 +1,1 @@
+/tailnet-share/personal/projects/openGym/frontend/node_modules

--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,1 +1,0 @@
-/tailnet-share/personal/projects/openGym/frontend/node_modules

--- a/frontend/src/lib/history.js
+++ b/frontend/src/lib/history.js
@@ -142,6 +142,60 @@ export function cleanupSg(ex) {
   })
 }
 
+// Return the contiguous run around an entry that shares its superset id. A repeated id in a
+// separated part of the list is deliberately not included: the display semantics are adjacent
+// entries sharing one id, not every entry that happens to carry that id.
+function contiguousSgGroup(items, idx) {
+  const sg = items[idx]?.sg
+  if (!sg) return [idx]
+  let first = idx
+  let last = idx
+  while (first > 0 && items[first - 1]?.sg === sg) first--
+  while (last + 1 < items.length && items[last + 1]?.sg === sg) last++
+  return Array.from({ length: last - first + 1 }, (_, i) => first + i)
+}
+
+function freshSg(items, first, second) {
+  const base = `sg-${Math.min(first, second)}-${Math.max(first, second)}`
+  let sg = base
+  let n = 2
+  while (items.some(e => e.sg === sg)) sg = `${base}-${n++}`
+  return sg
+}
+
+// Purely pair two adjacent entries. Existing contiguous groups on either side are merged, so
+// pairing the end of one group with the start of another produces one display unit. A caller can
+// provide a group id (useful when restoring a known id); otherwise an existing id is preferred,
+// with a deterministic unused id for two previously ungrouped entries.
+export function pairAdjacent(items, first, second, groupId) {
+  if (!Array.isArray(items)) throw new TypeError('Superset entries must be an array')
+  if (!Number.isInteger(first) || !Number.isInteger(second) || !items[first] || !items[second]) {
+    throw new RangeError('Superset entry indexes are invalid')
+  }
+  if (Math.abs(first - second) !== 1) throw new RangeError('Superset entries must be adjacent')
+
+  const next = items.map(e => ({ ...e }))
+  const left = Math.min(first, second)
+  const right = Math.max(first, second)
+  const group = groupId || next[left].sg || next[right].sg || freshSg(next, left, right)
+  const members = new Set([...contiguousSgGroup(next, left), ...contiguousSgGroup(next, right)])
+  members.forEach(i => { next[i].sg = group })
+  return next
+}
+
+// Remove one entry from its superset and clean any ids that no longer have an adjacent partner.
+// This is pure so the active workout can replace its entries atomically through the store.
+export function unpairSuperset(items, idx) {
+  if (!Array.isArray(items)) throw new TypeError('Superset entries must be an array')
+  if (!Number.isInteger(idx) || !items[idx]) throw new RangeError('Superset entry index is invalid')
+  const next = items.map(e => ({ ...e }))
+  delete next[idx].sg
+  next.forEach((e, i) => {
+    if (e.sg && !(next[i - 1]?.sg === e.sg || next[i + 1]?.sg === e.sg)) delete e.sg
+  })
+  return next
+}
+
 export function lastEntryFor(S, exId) {
   for (let i = S.workouts.length - 1; i >= 0; i--) {
     const en = S.workouts[i].entries.find(e => e.id === exId)

--- a/frontend/src/lib/history.test.js
+++ b/frontend/src/lib/history.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { modeOf, isTimed, fmtSec, setLabel, defaultConfig, buildSets, freestyleConfig, exLine, workoutVolume, effortOf, stepEffort, capEffort, isBw, isPerSide, sideReps, repStep, cascadeWeight, insertWarmupRow, removeRowAt } from './history.js'
+import { modeOf, isTimed, fmtSec, setLabel, defaultConfig, buildSets, freestyleConfig, exLine, workoutVolume, effortOf, stepEffort, capEffort, isBw, isPerSide, sideReps, repStep, cascadeWeight, insertWarmupRow, removeRowAt, pairAdjacent, unpairSuperset, supersetUnits } from './history.js'
 import { EXDB } from './exercises.js'
 
 // Real ids out of the shipped catalogue, so the body-part fallback is exercised for real.
@@ -8,6 +8,49 @@ const CARDIO = EXDB.find(e => e.bp === 'cardio').id
 // defaults to bodyweight and would quietly send every label test down the other path.
 const LIFT = EXDB.find(e => e.bp !== 'cardio' && e.eq !== 'body weight').id
 const BW = EXDB.find(e => e.eq === 'body weight').id
+
+describe('superset editing', () => {
+  it('pairs adjacent entries without mutating the source and keeps the display units contiguous', () => {
+    const entries = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+
+    const paired = pairAdjacent(entries, 1, 2, 'sg-new')
+
+    expect(paired).toEqual([{ id: 'a' }, { id: 'b', sg: 'sg-new' }, { id: 'c', sg: 'sg-new' }])
+    expect(entries).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
+    expect(supersetUnits(paired)).toEqual([[0], [1, 2]])
+  })
+
+  it('merges both contiguous groups when their boundary entries are paired', () => {
+    const entries = [
+      { id: 'a', sg: 'left' }, { id: 'b', sg: 'left' },
+      { id: 'c', sg: 'right' }, { id: 'd', sg: 'right' }
+    ]
+
+    const merged = pairAdjacent(entries, 1, 2)
+
+    expect(merged.map(e => e.sg)).toEqual(['left', 'left', 'left', 'left'])
+    expect(entries.map(e => e.sg)).toEqual(['left', 'left', 'right', 'right'])
+  })
+
+  it('unpairs one entry and removes sg values left without an adjacent partner', () => {
+    const entries = [
+      { id: 'a', sg: 'group' }, { id: 'b', sg: 'group' }, { id: 'c', sg: 'group' },
+      { id: 'd', sg: 'orphan' }
+    ]
+
+    const unpaired = unpairSuperset(entries, 1)
+
+    expect(unpaired).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }])
+    expect(entries.map(e => e.sg)).toEqual(['group', 'group', 'group', 'orphan'])
+  })
+
+  it('rejects a non-adjacent pairing request', () => {
+    const entries = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+
+    expect(() => pairAdjacent(entries, 0, 2, 'sg-invalid')).toThrow(/adjacent/)
+    expect(entries).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
+  })
+})
 
 describe('modeOf', () => {
   it('falls back to the body part when a plan has no mode — every existing plan keeps working', () => {

--- a/frontend/src/locales/de.js
+++ b/frontend/src/locales/de.js
@@ -169,7 +169,7 @@ export default {
   'The sets you logged in this session will be lost.': 'Die in dieser Einheit eingetragenen Sätze gehen verloren.',
   'Superset {0} / {1}': 'Supersatz {0} / {1}',
   'Exercise {0} / {1}': 'Übung {0} / {1}',
-  'Superset · do these back-to-back, rest after both': 'Supersatz · direkt nacheinander, Pause erst danach',
+  'Superset · do these back-to-back, rest when done': 'Supersatz · direkt nacheinander, Pause erst danach',
   'Freestyle workout — add your first exercise.': 'Freies Training — füge deine erste Übung hinzu.',
   'Finish workout early · {0} exercises': 'Training vorzeitig beenden · {0} Übungen',
   'Rest over — next set!': 'Pause vorbei — nächster Satz!',

--- a/frontend/src/locales/de.js
+++ b/frontend/src/locales/de.js
@@ -584,4 +584,7 @@ export default {
   '{0} per side': '{0} pro Seite',
   'You still log the total: {0} is {1} per side.': 'Du trägst weiterhin die Gesamtzahl ein: {0} sind {1} pro Seite.',
   '{0} sets · {1} work': '{0} Sätze · {1} Arbeit',
+  'Make superset with previous': 'Mit vorheriger Übung kombinieren',
+  'Make superset with next': 'Mit nächster Übung kombinieren',
+  'Unpair': 'Trennen'
 }

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} por lado',
   'You still log the total: {0} is {1} per side.': 'Sigues registrando el total: {0} son {1} por lado.',
   '{0} sets · {1} work': '{0} series · {1} trabajo',
+  'Make superset with previous': 'Hacer superserie con anterior',
+  'Make superset with next': 'Hacer superserie con siguiente',
+  'Unpair': 'Desvincular'
 }

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -162,7 +162,7 @@ export default {
   'The sets you logged in this session will be lost.': 'Las series registradas en esta sesión se perderán.',
   'Superset {0} / {1}': 'Superserie {0} / {1}',
   'Exercise {0} / {1}': 'Ejercicio {0} / {1}',
-  'Superset · do these back-to-back, rest after both': 'Superserie · hazlos seguidos, descansa después de ambos',
+  'Superset · do these back-to-back, rest when done': 'Superserie · hazlos seguidos, descansa al final',
   'Freestyle workout — add your first exercise.': 'Entrenamiento libre — añade tu primer ejercicio.',
   'Finish workout early · {0} exercises': 'Terminar antes · {0} ejercicios',
   'Rest over — next set!': '¡Descanso terminado — siguiente serie!',

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -162,7 +162,7 @@ export default {
   'The sets you logged in this session will be lost.': 'Les séries notées dans cette session seront perdues.',
   'Superset {0} / {1}': 'Superset {0} / {1}',
   'Exercise {0} / {1}': 'Exercice {0} / {1}',
-  'Superset · do these back-to-back, rest after both': 'Superset · enchaîne-les, repos après les deux',
+  'Superset · do these back-to-back, rest when done': 'Superset · enchaîne-les, repos à la fin',
   'Freestyle workout — add your first exercise.': 'Séance libre — ajoute ton premier exercice.',
   'Finish workout early · {0} exercises': 'Terminer plus tôt · {0} exercices',
   'Rest over — next set!': 'Repos fini — série suivante !',

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} par côté',
   'You still log the total: {0} is {1} per side.': 'Tu notes toujours le total : {0}, c’est {1} par côté.',
   '{0} sets · {1} work': '{0} séries · {1} travail',
+  'Make superset with previous': 'Faire un superset avec le précédent',
+  'Make superset with next': 'Faire un superset avec le suivant',
+  'Unpair': 'Dissocier'
 }

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': 'प्रति तरफ़ {0}',
   'You still log the total: {0} is {1} per side.': 'आप कुल ही दर्ज करते हैं: {0} यानी प्रति तरफ़ {1}।',
   '{0} sets · {1} work': '{0} सेट · {1} काम',
+  'Make superset with previous': 'पिछले के साथ सुपरसेट',
+  'Make superset with next': 'अगले के साथ सुपरसेट',
+  'Unpair': 'अलग करें'
 }

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -162,7 +162,7 @@ export default {
   'The sets you logged in this session will be lost.': 'इस सत्र में दर्ज किए सेट खो जाएँगे।',
   'Superset {0} / {1}': 'सुपरसेट {0} / {1}',
   'Exercise {0} / {1}': 'व्यायाम {0} / {1}',
-  'Superset · do these back-to-back, rest after both': 'सुपरसेट · इन्हें लगातार करें, दोनों के बाद आराम',
+  'Superset · do these back-to-back, rest when done': 'सुपरसेट · इन्हें लगातार करें, अंत में आराम',
   'Freestyle workout — add your first exercise.': 'फ्रीस्टाइल वर्कआउट — पहला व्यायाम जोड़ें।',
   'Finish workout early · {0} exercises': 'जल्दी समाप्त करें · {0} व्यायाम',
   'Rest over — next set!': 'आराम खत्म — अगला सेट!',

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} per lato',
   'You still log the total: {0} is {1} per side.': 'Registri sempre il totale: {0} sono {1} per lato.',
   '{0} sets · {1} work': '{0} serie · {1} lavoro',
+  'Make superset with previous': 'Superset con il precedente',
+  'Make superset with next': 'Superset con il successivo',
+  'Unpair': 'Separa'
 }

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -162,7 +162,7 @@ export default {
   'The sets you logged in this session will be lost.': 'Le serie registrate in questa sessione andranno perse.',
   'Superset {0} / {1}': 'Superset {0} / {1}',
   'Exercise {0} / {1}': 'Esercizio {0} / {1}',
-  'Superset · do these back-to-back, rest after both': 'Superset · falli uno dopo l’altro, riposo dopo entrambi',
+  'Superset · do these back-to-back, rest when done': 'Superset · falli uno dopo l’altro, riposo alla fine',
   'Freestyle workout — add your first exercise.': 'Allenamento libero — aggiungi il primo esercizio.',
   'Finish workout early · {0} exercises': 'Termina in anticipo · {0} esercizi',
   'Rest over — next set!': 'Riposo finito — prossima serie!',

--- a/frontend/src/locales/ko.js
+++ b/frontend/src/locales/ko.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '한쪽당 {0}회',
   'You still log the total: {0} is {1} per side.': '기록은 그대로 합계로 합니다: {0}회는 한쪽당 {1}회입니다.',
   '{0} sets · {1} work': '{0} 세트 · {1} 작업',
+  'Make superset with previous': '이전 운동과 슈퍼셋',
+  'Make superset with next': '다음 운동과 슈퍼셋',
+  'Unpair': '분리'
 }

--- a/frontend/src/locales/ko.js
+++ b/frontend/src/locales/ko.js
@@ -162,7 +162,7 @@ export default {
   'The sets you logged in this session will be lost.': '이 세션에서 기록한 세트가 사라집니다.',
   'Superset {0} / {1}': '슈퍼세트 {0} / {1}',
   'Exercise {0} / {1}': '운동 {0} / {1}',
-  'Superset · do these back-to-back, rest after both': '슈퍼세트 · 연달아 수행하고, 둘 다 끝난 뒤 휴식',
+  'Superset · do these back-to-back, rest when done': '슈퍼세트 · 연달아 수행하고, 전부 끝난 뒤 휴식',
   'Freestyle workout — add your first exercise.': '자유 운동 — 첫 운동을 추가하세요.',
   'Finish workout early · {0} exercises': '일찍 마치기 · 운동 {0}개',
   'Rest over — next set!': '휴식 끝 — 다음 세트!',

--- a/frontend/src/locales/pl.js
+++ b/frontend/src/locales/pl.js
@@ -162,7 +162,7 @@ export default {
   'The sets you logged in this session will be lost.': 'Serie zapisane w tej sesji zostaną utracone.',
   'Superset {0} / {1}': 'Superseria {0} / {1}',
   'Exercise {0} / {1}': 'Ćwiczenie {0} / {1}',
-  'Superset · do these back-to-back, rest after both': 'Superseria · rób jedno po drugim, odpocznij po obu',
+  'Superset · do these back-to-back, rest when done': 'Superseria · rób jedno po drugim, odpocznij na końcu',
   'Freestyle workout — add your first exercise.': 'Trening dowolny — dodaj pierwsze ćwiczenie.',
   'Finish workout early · {0} exercises': 'Zakończ wcześniej · {0} ćwiczeń',
   'Rest over — next set!': 'Koniec przerwy — następna seria!',

--- a/frontend/src/locales/pl.js
+++ b/frontend/src/locales/pl.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} na stronę',
   'You still log the total: {0} is {1} per side.': 'Nadal zapisujesz łączną liczbę: {0} to {1} na stronę.',
   '{0} sets · {1} work': '{0} serii · {1} praca',
+  'Make superset with previous': 'Połącz z poprzednim',
+  'Make superset with next': 'Połącz z następnym',
+  'Unpair': 'Rozłącz'
 }

--- a/frontend/src/locales/pt.js
+++ b/frontend/src/locales/pt.js
@@ -162,7 +162,7 @@ export default {
   'The sets you logged in this session will be lost.': 'As séries registadas nesta sessão vão perder-se.',
   'Superset {0} / {1}': 'Supersérie {0} / {1}',
   'Exercise {0} / {1}': 'Exercício {0} / {1}',
-  'Superset · do these back-to-back, rest after both': 'Supersérie · faz seguidos, descansa depois de ambos',
+  'Superset · do these back-to-back, rest when done': 'Supersérie · faz seguidos, descansa no final',
   'Freestyle workout — add your first exercise.': 'Treino livre — adiciona o teu primeiro exercício.',
   'Finish workout early · {0} exercises': 'Terminar mais cedo · {0} exercícios',
   'Rest over — next set!': 'Descanso terminado — próxima série!',

--- a/frontend/src/locales/pt.js
+++ b/frontend/src/locales/pt.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} por lado',
   'You still log the total: {0} is {1} per side.': 'Continuas a registar o total: {0} são {1} por lado.',
   '{0} sets · {1} work': '{0} séries · {1} trabalho',
+  'Make superset with previous': 'Fazer superset com o anterior',
+  'Make superset with next': 'Fazer superset com o próximo',
+  'Unpair': 'Desfazer'
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} на сторону',
   'You still log the total: {0} is {1} per side.': 'Ты по-прежнему записываешь общее число: {0} — это {1} на сторону.',
   '{0} sets · {1} work': '{0} подходов · {1} рабочих',
+  'Make superset with previous': 'Суперсет с предыдущим',
+  'Make superset with next': 'Суперсет со следующим',
+  'Unpair': 'Разъединить'
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -162,7 +162,7 @@ export default {
   'The sets you logged in this session will be lost.': 'Подходы, записанные в этой сессии, будут потеряны.',
   'Superset {0} / {1}': 'Суперсет {0} / {1}',
   'Exercise {0} / {1}': 'Упражнение {0} / {1}',
-  'Superset · do these back-to-back, rest after both': 'Суперсет · выполняй подряд, отдых после обоих',
+  'Superset · do these back-to-back, rest when done': 'Суперсет · выполняй подряд, отдых в конце',
   'Freestyle workout — add your first exercise.': 'Свободная тренировка — добавь первое упражнение.',
   'Finish workout early · {0} exercises': 'Завершить раньше · упражнений: {0}',
   'Rest over — next set!': 'Отдых окончен — следующий подход!',

--- a/frontend/src/locales/tr.js
+++ b/frontend/src/locales/tr.js
@@ -162,7 +162,7 @@ export default {
   'The sets you logged in this session will be lost.': 'Bu oturumda kaydettiğin setler kaybolacak.',
   'Superset {0} / {1}': 'Süperset {0} / {1}',
   'Exercise {0} / {1}': 'Egzersiz {0} / {1}',
-  'Superset · do these back-to-back, rest after both': 'Süperset · art arda yap, ikisinden sonra dinlen',
+  'Superset · do these back-to-back, rest when done': 'Süperset · art arda yap, sonunda dinlen',
   'Freestyle workout — add your first exercise.': 'Serbest antrenman — ilk egzersizini ekle.',
   'Finish workout early · {0} exercises': 'Erken bitir · {0} egzersiz',
   'Rest over — next set!': 'Dinlenme bitti — sıradaki set!',

--- a/frontend/src/locales/tr.js
+++ b/frontend/src/locales/tr.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': 'Taraf başına {0}',
   'You still log the total: {0} is {1} per side.': 'Toplamı kaydetmeye devam ediyorsun: {0}, taraf başına {1} demek.',
   '{0} sets · {1} work': '{0} set · {1} çalışma',
+  'Make superset with previous': 'Öncekiyle superset yap',
+  'Make superset with next': 'Sonrakiyle superset yap',
+  'Unpair': 'Ayır'
 }

--- a/frontend/src/locales/zh.js
+++ b/frontend/src/locales/zh.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '每侧 {0} 次',
   'You still log the total: {0} is {1} per side.': '你记录的仍然是总数：{0} 表示每侧 {1} 次。',
   '{0} sets · {1} work': '{0} 组 · {1} 工作',
+  'Make superset with previous': '与上一个组成超级组',
+  'Make superset with next': '与下一个组成超级组',
+  'Unpair': '取消组合'
 }

--- a/frontend/src/locales/zh.js
+++ b/frontend/src/locales/zh.js
@@ -162,7 +162,7 @@ export default {
   'The sets you logged in this session will be lost.': '本次记录的组数将丢失。',
   'Superset {0} / {1}': '超级组 {0} / {1}',
   'Exercise {0} / {1}': '动作 {0} / {1}',
-  'Superset · do these back-to-back, rest after both': '超级组 · 连续完成，两个都做完再休息',
+  'Superset · do these back-to-back, rest when done': '超级组 · 连续完成，全部做完再休息',
   'Freestyle workout — add your first exercise.': '自由训练——添加你的第一个动作。',
   'Finish workout early · {0} exercises': '提前结束 · {0} 个动作',
   'Rest over — next set!': '休息结束——下一组！',

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
 import { useUI } from '../store/useUI.js'
 import { exOr } from '../lib/exercises.js'
-import { effectiveRoutine, lastEntryFor, bestWeightFor, buildSets, freestyleConfig, defaultConfig, setsDoneActive, supersetUnits, unitOf, setLabel, modeOf, isBw, isPerSide, sideReps, repStep, EFFORT, effortOf, stepEffort, capEffort, cascadeWeight, insertWarmupRow, removeRowAt } from '../lib/history.js'
+import { effectiveRoutine, lastEntryFor, bestWeightFor, buildSets, freestyleConfig, defaultConfig, setsDoneActive, supersetUnits, unitOf, setLabel, modeOf, isBw, isPerSide, sideReps, repStep, EFFORT, effortOf, stepEffort, capEffort, cascadeWeight, insertWarmupRow, removeRowAt, pairAdjacent, unpairSuperset } from '../lib/history.js'
 import { fmtNum, fmtDate, todayISO, exCount, DAYN } from '../lib/format.js'
 import { beep, vibrate } from '../lib/sound.js'
 import { t } from '../lib/i18n.js'
@@ -54,7 +54,7 @@ function Elapsed({ start }) {
 }
 
 /* ---------- one exercise block (reps: weight×reps · time: a held duration · cardio: duration+speed) ---------- */
-function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemoveSet, onAddWarmup, onRemoveSetAt, onStartTimed }) {
+function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemoveSet, onAddWarmup, onRemoveSetAt, onStartTimed, onPairPrev, onPairNext }) {
   const S = useStore(s => s.S)
   const working = useUI(s => s.work)
   const entry = S.active.entries[entryIdx]
@@ -114,6 +114,10 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
       <div style={{ fontSize: compact ? 17 : 20, fontWeight: 600, letterSpacing: '-.02em', textTransform: 'capitalize', lineHeight: 1.2 }}>{ex.n}</div>
       <button className="iconbtn" aria-label={t('Details')} onClick={() => exerciseDetailSheet(ex)}><Icon name="info" /></button>
     </div>
+    {!compact && (onPairPrev || onPairNext) && <div className="row" style={{ gap: 6, flexWrap: 'wrap', marginBottom: 8 }}>
+      {onPairPrev && <Button size="xs" variant="tinted" icon="link" title={t('Make superset with previous')} onClick={onPairPrev}>{t('Make superset with previous')}</Button>}
+      {onPairNext && <Button size="xs" variant="tinted" icon="link" title={t('Make superset with next')} onClick={onPairNext}>{t('Make superset with next')}</Button>}
+    </div>}
     <div className="row" style={{ gap: 6, flexWrap: 'wrap', marginBottom: 8 }}>
       {cardio && <span className="tag acc"><Icon name="figureRun" />{t('Cardio')}</span>}
       {/* You log the total; this is the split, so the set in front of you is unambiguous
@@ -205,6 +209,14 @@ function ActiveWorkout() {
     e.sets = insertWarmupRow(e.sets, m, e.target || {})
   })
   const removeSetAt = (idx, i) => mutEntry(idx, e => { e.sets = removeRowAt(e.sets, i) })
+  const pairAt = (first, second) => update(s => {
+    s.active.entries = pairAdjacent(s.active.entries, first, second)
+  })
+  const unpairAt = idx => update(s => {
+    s.active.entries = unpairSuperset(s.active.entries, idx)
+  })
+  const onPairPrev = !isSuperset && cur > 0 ? () => pairAt(cur - 1, cur) : null
+  const onPairNext = !isSuperset && cur < A.entries.length - 1 ? () => pairAt(cur, cur + 1) : null
 
   // A timed set is held, not typed. The work timer records what was actually held — an early
   // finish logs 0:38 of a 0:45 target rather than crediting the full prescription — and then
@@ -286,7 +298,10 @@ function ActiveWorkout() {
       <div className="muted small" style={{ marginBottom: 6 }}>{isSuperset ? t('Superset {0} / {1}', unitIdx + 1, units.length) : t('Exercise {0} / {1}', unitIdx + 1, units.length)}</div>
       {isSuperset ? (
         <div className="ss-card">
-          <div className="ss-hd"><Icon name="link" />{t('Superset · do these back-to-back, rest after both')}</div>
+          <div className="ss-hd" style={{ justifyContent: 'space-between' }}>
+            <span className="row" style={{ gap: 5 }}><Icon name="link" />{t('Superset · do these back-to-back, rest after both')}</span>
+            <Button size="xs" variant="ghost" icon="link" title={t('Unpair')} onClick={() => unpairAt(cur)}>{t('Unpair')}</Button>
+          </div>
           {unit.map((idx, k) => <div key={idx} className="ss-ex">
             {k > 0 && <div className="ss-amp">+</div>}
             <ExerciseBlock entryIdx={idx} compact
@@ -294,7 +309,7 @@ function ActiveWorkout() {
           </div>)}
         </div>
       ) : (
-        <ExerciseBlock entryIdx={cur} onToggle={i => toggle(cur, i)} onField={(i, f, v) => setField(cur, i, f, v)} onAddSet={() => addSet(cur)} onRemoveSet={() => removeSet(cur)} onAddWarmup={() => addWarmup(cur)} onRemoveSetAt={i => removeSetAt(cur, i)} onStartTimed={i => startTimed(cur, i)} />
+        <ExerciseBlock entryIdx={cur} onToggle={i => toggle(cur, i)} onField={(i, f, v) => setField(cur, i, f, v)} onAddSet={() => addSet(cur)} onRemoveSet={() => removeSet(cur)} onAddWarmup={() => addWarmup(cur)} onRemoveSetAt={i => removeSetAt(cur, i)} onStartTimed={i => startTimed(cur, i)} onPairPrev={onPairPrev} onPairNext={onPairNext} />
       )}
     </> : <div className="empty"><div className="ico"><Icon name="shuffle" /></div>{t('Freestyle workout — add your first exercise.')}</div>}
 

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -299,7 +299,7 @@ function ActiveWorkout() {
       {isSuperset ? (
         <div className="ss-card">
           <div className="ss-hd" style={{ justifyContent: 'space-between' }}>
-            <span className="row" style={{ gap: 5 }}><Icon name="link" />{t('Superset · do these back-to-back, rest after both')}</span>
+            <span className="row" style={{ gap: 5 }}><Icon name="link" />{t('Superset · do these back-to-back, rest when done')}</span>
             <Button size="xs" variant="ghost" icon="link" title={t('Unpair')} onClick={() => unpairAt(cur)}>{t('Unpair')}</Button>
           </div>
           {unit.map((idx, k) => <div key={idx} className="ss-ex">


### PR DESCRIPTION
## Session supersets — pair exercises straight from the workout screen

Pair two exercises mid-session and they log as one superset unit (do them back-to-back, rest after both). Unpair whenever you like.

**What's here:**
- **Pair/unpair controls on each exercise card** — "Make superset with previous" / "Make superset with next" appear next to the exercise header; paired exercises collapse into a single *Superset* card with an **Unpair** button in its header.
- **Groups can be any size** — pairing the end of one group with the start of another merges them; the header uses neutral wording ("rest when done") so it stays correct for 2+ exercises.
- **Pure, adjacency-validated helpers** (`pairAdjacent` / `unpairSuperset` in `history.js`) — no mutation of the active session, deterministic cleanup of orphaned group ids.
- **Coexists with warm-up row controls** and the set-growth guard from #48 — verified against current main.
- Labels translated in all 11 locales; tests for pairing, merging, unpairing and adjacency validation.

Verified on a live deployment before opening (owner-tested); happy to adjust anything.