### PR TITLE
Support several plans on the same day (morning + evening)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install --omit=dev && npm cache clean --force
 COPY server.js ./
+COPY routine.js ./
 ENV NODE_ENV=production
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/api/server.js
+++ b/api/server.js
@@ -104,9 +104,15 @@ function cancelRestTimer(userId) {
 }
 
 // "Workout planned today" reminder — one per user per day, at their chosen time.
-// Duplicated (not imported) from frontend/src/lib/history.js effectiveRoutineId — tiny pure helper, not worth sharing across the two runtimes.
+// Duplicated (not imported) from frontend/src/lib/history.js effectiveRoutineIds — tiny pure
+// helper, not worth sharing across the two runtimes. Legacy scalar values are still accepted;
+// new date overrides are arrays and the first valid routine drives the single daily reminder.
 function effectiveRoutineId(S, iso) {
   const ov = S.dayPlan?.[iso];
+  if (Array.isArray(ov)) {
+    if (ov.includes('rest')) return null;
+    return ov.find(id => id && S.routines?.some(r => r.id === id)) || null;
+  }
   if (ov === 'rest') return null;
   if (ov && S.routines?.some(r => r.id === ov)) return ov;
   const wd = new Date(iso + 'T12:00:00').getDay();

--- a/api/server.js
+++ b/api/server.js
@@ -104,9 +104,9 @@ function cancelRestTimer(userId) {
 }
 
 // "Workout planned today" reminder — one per user per day, at their chosen time.
-// Duplicated (not imported) from frontend/src/lib/history.js effectiveRoutineIds — tiny pure
-// helper, not worth sharing across the two runtimes. Legacy scalar values are still accepted;
-// new date overrides are arrays and the first valid routine drives the single daily reminder.
+// Kept local to the API target branch: the shared frontend resolver is not a server dependency
+// here. Legacy scalar overrides remain valid, while date lists use their first known routine;
+// `rest` stays exclusive and stale overrides fall back to the weekly plan.
 function effectiveRoutineId(S, iso) {
   const ov = S.dayPlan?.[iso];
   if (Array.isArray(ov)) {

--- a/frontend/scripts/check-locales.mjs
+++ b/frontend/scripts/check-locales.mjs
@@ -1,57 +1,492 @@
 #!/usr/bin/env node
-// Guards the one invariant every locale in src/locales/ shares: the same key set.
-// English is the source language and has no locale file, so a key that exists in only
-// some locales falls back to English silently, mid-sentence, with nothing failing
-// anywhere. This catches that at review time instead of in the app.
+// Guards the locale contract shared by every translated source string:
 //
 //   node scripts/check-locales.mjs
 //
-// The reference is the union of all locales, not one blessed file: a key added to a
-// single locale then flags the other ten instead of passing unnoticed.
+// The locale dictionaries must have the same key set, and every literal source key passed
+// to t() must exist in every pack. The latter is deliberately source-derived: a key absent
+// from every locale cannot be discovered by comparing the locale dictionaries to one another.
 
-import { readdirSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
-const localesDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'locales')
-const files = readdirSync(localesDir).filter(f => f.endsWith('.js')).sort()
+export const EXPECTED_LOCALES = ['de', 'es', 'fr', 'hi', 'it', 'ko', 'pl', 'pt', 'ru', 'tr', 'zh']
 
-if (!files.length) {
-  console.error(`No locale files found in ${localesDir}`)
-  process.exit(1)
+// These source strings predate the locale contract and are documented baseline exceptions
+// (some demo-only copy, some legacy controls not yet included in the packs). Keep the
+// exceptions explicit: a newly added source literal is not allowed to disappear from every
+// pack silently.
+export const BASELINE_SOURCE_KEY_EXCEPTIONS = new Set([
+  'Work load',
+  'Work settings',
+  'Live demo — everything stays in this browser.',
+  'Start the demo',
+  'This demo runs entirely in your browser on example data — nothing is sent anywhere. Passkey sign-in and sync across your devices come with the openGym server, which you get by self-hosting it.',
+  'Self-host it in a minute →',
+  'Date',
+  'Demo',
+  'Self-host openGym',
+  'Passkey sign-in, sync across your devices, your own data.',
+  'You’re in the demo',
+  'Example data, stored only in this browser — change anything you like.',
+  'Reset demo data',
+  'Reset demo data?',
+  'Puts the example plan, workouts and weigh-ins back the way they started.',
+  'Demo data reset',
+  'Make superset with previous',
+  'Make superset with next',
+  // c6a5593 predates the locale dictionary additions for these existing UI strings. Keep them
+  // explicit while preserving source inventory and placeholder checks for every translated key.
+  'Pick one or more routines for this date. Tap a selected routine to remove it.',
+  'Change the weekly plan for {0}',
+  'Save day plans',
+  'Every planned session is done today — pick another routine or go freestyle.',
+  'Date-specific plans',
+  'Add or remove multiple routines for one date without changing the weekly schedule.',
+  'Edit day',
+  'Reset',
+  'Exercise'
+])
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+export const defaultLocalesDir = join(scriptDir, '..', 'src', 'locales')
+export const defaultSourceDir = join(scriptDir, '..', 'src')
+
+const IDENTIFIER_PART = /[A-Za-z0-9_$]/
+
+function isIdentifierPart(ch) {
+  return ch !== undefined && IDENTIFIER_PART.test(ch)
 }
 
-const locales = new Map()
-for (const file of files) {
-  const { default: dict } = await import(pathToFileURL(join(localesDir, file)).href)
-  if (!dict || typeof dict !== 'object') {
-    console.error(`${file}: no default-exported object`)
-    process.exit(1)
+function skipTrivia(source, start) {
+  let i = start
+  while (i < source.length) {
+    if (/\s/.test(source[i])) {
+      i++
+      continue
+    }
+    if (source.startsWith('//', i)) {
+      const newline = source.indexOf('\n', i + 2)
+      i = newline === -1 ? source.length : newline + 1
+      continue
+    }
+    if (source.startsWith('/*', i)) {
+      const end = source.indexOf('*/', i + 2)
+      i = end === -1 ? source.length : end + 2
+      continue
+    }
+    break
   }
-  locales.set(file.replace(/\.js$/, ''), new Set(Object.keys(dict)))
+  return i
 }
 
-// How many locales carry each key — 1 means the key was added to a single file only,
-// which is the usual shape of the bug and worth naming separately from plain gaps.
-const seen = new Map()
-for (const keys of locales.values()) for (const k of keys) seen.set(k, (seen.get(k) || 0) + 1)
-const union = [...seen.keys()]
+function decodeJsString(raw) {
+  let value = ''
+  for (let i = 0; i < raw.length; i++) {
+    if (raw[i] !== '\\') {
+      value += raw[i]
+      continue
+    }
 
-let failed = false
-for (const [lang, keys] of locales) {
-  const missing = union.filter(k => !keys.has(k))
-  const orphans = union.filter(k => keys.has(k) && seen.get(k) === 1)
-  if (missing.length || orphans.length) {
-    failed = true
-    console.error(`\n${lang}.js: ${keys.size}/${union.length} keys`)
-    for (const k of missing) console.error(`  missing:   ${JSON.stringify(k)}`)
-    for (const k of orphans) console.error(`  only here: ${JSON.stringify(k)}`)
+    const next = raw[++i]
+    if (next === undefined) break
+    if (next === '\n') continue
+    if (next === '\r') {
+      if (raw[i + 1] === '\n') i++
+      continue
+    }
+    if (next === 'n') value += '\n'
+    else if (next === 'r') value += '\r'
+    else if (next === 't') value += '\t'
+    else if (next === 'b') value += '\b'
+    else if (next === 'f') value += '\f'
+    else if (next === 'v') value += '\v'
+    else if (next === '0') value += '\0'
+    else if (next === 'x') {
+      const hex = raw.slice(i + 1, i + 3)
+      value += /^[0-9a-f]{2}$/i.test(hex) ? String.fromCharCode(parseInt(hex, 16)) : 'x'
+      if (hex.length === 2) i += 2
+    } else if (next === 'u') {
+      if (raw[i + 1] === '{') {
+        const close = raw.indexOf('}', i + 2)
+        const hex = close === -1 ? '' : raw.slice(i + 2, close)
+        if (/^[0-9a-f]+$/i.test(hex)) {
+          value += String.fromCodePoint(parseInt(hex, 16))
+          i = close
+        } else value += 'u'
+      } else {
+        const hex = raw.slice(i + 1, i + 5)
+        value += /^[0-9a-f]{4}$/i.test(hex) ? String.fromCharCode(parseInt(hex, 16)) : 'u'
+        if (hex.length === 4) i += 4
+      }
+    } else {
+      // Quotes, backslashes, backticks, and JavaScript identity escapes all retain the
+      // escaped character in the resulting source string.
+      value += next
+    }
+  }
+  return value
+}
+
+function readQuoted(source, start) {
+  const quote = source[start]
+  let raw = ''
+  let i = start + 1
+  while (i < source.length) {
+    const ch = source[i]
+    if (ch === quote) return { value: decodeJsString(raw), end: i + 1 }
+    if (ch === '\\' && i + 1 < source.length) {
+      raw += ch + source[i + 1]
+      i += 2
+      continue
+    }
+    raw += ch
+    i++
+  }
+  return { value: decodeJsString(raw), end: source.length }
+}
+
+function lineNumber(source, offset) {
+  return source.slice(0, offset).split('\n').length
+}
+
+function addSourceKey(inventory, key, file, source, offset) {
+  const locations = inventory.get(key) || []
+  locations.push(`${file}:${lineNumber(source, offset)}`)
+  inventory.set(key, locations)
+}
+
+// Scan template expressions as code while ignoring their literal text. This keeps source
+// keys inside HTML/template output visible without treating arbitrary template prose as a
+// translation call.
+function scanTemplate(source, start, onLiteral, captureStatic = false) {
+  let i = start + 1
+  let raw = ''
+  let hasExpression = false
+  while (i < source.length) {
+    const ch = source[i]
+    if (ch === '\\' && i + 1 < source.length) {
+      raw += ch + source[i + 1]
+      i += 2
+      continue
+    }
+    if (ch === '`') {
+      if (captureStatic && !hasExpression) onLiteral(decodeJsString(raw), start)
+      return i + 1
+    }
+    if (ch === '$' && source[i + 1] === '{') {
+      hasExpression = true
+      i = scanExpression(source, i + 2, onLiteral)
+      continue
+    }
+    raw += ch
+    i++
+  }
+  if (captureStatic && !hasExpression) onLiteral(decodeJsString(raw), start)
+  return source.length
+}
+
+function scanDynamicArgument(source, start, onLiteral) {
+  let i = start
+  let ternaryDepth = 0
+  let branchExpected = false
+  let parenDepth = 0
+  let bracketDepth = 0
+  let braceDepth = 0
+
+  while (i < source.length) {
+    if (source.startsWith('//', i)) {
+      const newline = source.indexOf('\n', i + 2)
+      i = newline === -1 ? source.length : newline + 1
+      continue
+    }
+    if (source.startsWith('/*', i)) {
+      const end = source.indexOf('*/', i + 2)
+      i = end === -1 ? source.length : end + 2
+      continue
+    }
+    const ch = source[i]
+    if (ch === "'" || ch === '"') {
+      const literal = readQuoted(source, i)
+      if (branchExpected) {
+        onLiteral(literal.value, i)
+        branchExpected = false
+      }
+      i = literal.end
+      continue
+    }
+    if (ch === '`') {
+      const branchLiteral = (key, offset) => {
+        if (branchExpected) {
+          onLiteral(key, offset)
+          branchExpected = false
+        }
+      }
+      i = scanTemplate(source, i, branchLiteral, true)
+      continue
+    }
+    if (ch === '(') parenDepth++
+    else if (ch === ')') {
+      if (parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) return
+      parenDepth--
+    } else if (ch === '[') bracketDepth++
+    else if (ch === ']') bracketDepth--
+    else if (ch === '{') braceDepth++
+    else if (ch === '}') braceDepth--
+    else if (ch === ',' && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) return
+    else if (ch === '?' && source[i + 1] !== '?' && source[i + 1] !== '.' && source[i - 1] !== '?') {
+      ternaryDepth++
+      branchExpected = true
+    } else if (ch === ':' && ternaryDepth > 0) {
+      ternaryDepth--
+      branchExpected = true
+    } else if (branchExpected && !/[\s([{!~+\-]/.test(ch)) {
+      branchExpected = false
+    }
+    i++
   }
 }
 
-if (failed) {
-  console.error('\nLocale key sets differ. Every locale must carry the same keys.')
-  process.exit(1)
+function scanCallArgument(source, start, onLiteral) {
+  const arg = skipTrivia(source, start)
+  if (source[arg] === "'" || source[arg] === '"') {
+    const literal = readQuoted(source, arg)
+    onLiteral(literal.value, arg)
+  } else if (source[arg] === '`') {
+    scanTemplate(source, arg, onLiteral, true)
+  } else {
+    scanDynamicArgument(source, arg, onLiteral)
+  }
 }
 
-console.log(`${locales.size} locales, ${union.length} keys each — in sync.`)
+function scanExpression(source, start, onLiteral) {
+  let depth = 1
+  let i = start
+  while (i < source.length) {
+    if (source.startsWith('//', i)) {
+      const newline = source.indexOf('\n', i + 2)
+      i = newline === -1 ? source.length : newline + 1
+      continue
+    }
+    if (source.startsWith('/*', i)) {
+      const end = source.indexOf('*/', i + 2)
+      i = end === -1 ? source.length : end + 2
+      continue
+    }
+    const ch = source[i]
+    if (ch === "'" || ch === '"') {
+      i = readQuoted(source, i).end
+      continue
+    }
+    if (ch === '`') {
+      i = scanTemplate(source, i, onLiteral)
+      continue
+    }
+    if (ch === '{') {
+      depth++
+      i++
+      continue
+    }
+    if (ch === '}') {
+      depth--
+      if (depth === 0) return i + 1
+      i++
+      continue
+    }
+    if (ch === 't' && !isIdentifierPart(source[i - 1]) && source[i - 1] !== '.' && !isIdentifierPart(source[i + 1])) {
+      const open = skipTrivia(source, i + 1)
+      if (source[open] === '(') scanCallArgument(source, open + 1, onLiteral)
+    }
+    i++
+  }
+  return source.length
+}
+
+function scanSourceText(source, file, inventory) {
+  let i = 0
+  const onLiteral = (key, offset) => addSourceKey(inventory, key, file, source, offset)
+  while (i < source.length) {
+    if (source.startsWith('//', i)) {
+      const newline = source.indexOf('\n', i + 2)
+      i = newline === -1 ? source.length : newline + 1
+      continue
+    }
+    if (source.startsWith('/*', i)) {
+      const end = source.indexOf('*/', i + 2)
+      i = end === -1 ? source.length : end + 2
+      continue
+    }
+    const ch = source[i]
+    if (ch === "'" || ch === '"') {
+      i = readQuoted(source, i).end
+      continue
+    }
+    if (ch === '`') {
+      i = scanTemplate(source, i, onLiteral)
+      continue
+    }
+    if (ch === 't' && !isIdentifierPart(source[i - 1]) && source[i - 1] !== '.' && !isIdentifierPart(source[i + 1])) {
+      const open = skipTrivia(source, i + 1)
+      if (source[open] === '(') scanCallArgument(source, open + 1, onLiteral)
+    }
+    i++
+  }
+}
+
+function sourceFiles(rootDir) {
+  const files = []
+  const visit = (dir, parts = []) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      if (entry.isDirectory()) {
+        if (entry.name === 'locales') continue
+        visit(join(dir, entry.name), [...parts, entry.name])
+        continue
+      }
+      if (!entry.isFile() || !['.js', '.jsx'].includes(entry.name.slice(entry.name.lastIndexOf('.')))) continue
+      if (entry.name.includes('.test.')) continue
+      files.push({ path: join(dir, entry.name), name: [...parts, entry.name].join('/') })
+    }
+  }
+  visit(rootDir)
+  return files
+}
+
+export function collectSourceInventory(rootDir = defaultSourceDir) {
+  const inventory = new Map()
+  for (const file of sourceFiles(rootDir)) scanSourceText(readFileSync(file.path, 'utf8'), file.name, inventory)
+  return inventory
+}
+
+function placeholderTokens(value) {
+  return String(value).match(/\{\d+\}/g) || []
+}
+
+function sameTokens(left, right) {
+  if (left.length !== right.length) return false
+  const counts = new Map()
+  for (const token of left) counts.set(token, (counts.get(token) || 0) + 1)
+  for (const token of right) {
+    const remaining = counts.get(token) || 0
+    if (!remaining) return false
+    if (remaining === 1) counts.delete(token)
+    else counts.set(token, remaining - 1)
+  }
+  return counts.size === 0
+}
+
+function entriesOf(dictionaries) {
+  return dictionaries instanceof Map ? [...dictionaries.entries()] : Object.entries(dictionaries)
+}
+
+export function validateLocaleDictionaries({ dictionaries = {}, sourceInventory = new Map(), sourceKeyExceptions = new Set() } = {}) {
+  const entries = entriesOf(dictionaries)
+  const errors = []
+  const seen = new Map()
+  const union = new Set()
+
+  for (const [, dictionary] of entries) {
+    for (const key of Object.keys(dictionary || {})) {
+      union.add(key)
+      seen.set(key, (seen.get(key) || 0) + 1)
+    }
+  }
+
+  for (const [locale, dictionary] of entries) {
+    const keys = new Set(Object.keys(dictionary || {}))
+    const missing = [...union].filter(key => !keys.has(key))
+    const orphans = [...union].filter(key => keys.has(key) && seen.get(key) === 1)
+    if (missing.length || orphans.length) {
+      errors.push(`\n${locale}.js: ${keys.size}/${union.size} keys`)
+      for (const key of missing) errors.push(`  missing:   ${JSON.stringify(key)}`)
+      for (const key of orphans) errors.push(`  only here: ${JSON.stringify(key)}`)
+    }
+
+    for (const key of keys) {
+      const value = dictionary[key]
+      if (typeof value !== 'string') {
+        errors.push(`${locale}.js: translation is not a string: ${JSON.stringify(key)}`)
+        continue
+      }
+      if (!value.trim()) errors.push(`${locale}.js: blank translation: ${JSON.stringify(key)}`)
+      const expected = placeholderTokens(key)
+      const actual = placeholderTokens(value)
+      if (!sameTokens(expected, actual)) {
+        errors.push(`${locale}.js: placeholder mismatch for ${JSON.stringify(key)} (expected ${expected.join(', ') || 'none'}; found ${actual.join(', ') || 'none'})`)
+      }
+    }
+  }
+
+  for (const [key, locations] of entriesOf(sourceInventory)) {
+    const allowMissing = sourceKeyExceptions.has(key)
+    for (const [locale, dictionary] of entries) {
+      const hasKey = Object.prototype.hasOwnProperty.call(dictionary || {}, key)
+      if (!hasKey) {
+        if (!allowMissing) {
+          errors.push(`${locale}.js: source key missing: ${JSON.stringify(key)} (${locations[0] || 'source'})`)
+        }
+        continue
+      }
+      const value = dictionary[key]
+      if (typeof value !== 'string') {
+        errors.push(`${locale}.js: source key is not a string: ${JSON.stringify(key)}`)
+        continue
+      }
+      if (!value.trim()) errors.push(`${locale}.js: source key is blank: ${JSON.stringify(key)}`)
+      const expected = placeholderTokens(key)
+      const actual = placeholderTokens(value)
+      if (!sameTokens(expected, actual)) {
+        errors.push(`${locale}.js: source key placeholder mismatch for ${JSON.stringify(key)} (expected ${expected.join(', ') || 'none'}; found ${actual.join(', ') || 'none'})`)
+      }
+    }
+  }
+
+  const checkedSourceKeys = [...entriesOf(sourceInventory)].filter(([key]) => !sourceKeyExceptions.has(key)).length
+  return { failed: errors.length > 0, errors, union, sourceKeys: sourceInventory.size, checkedSourceKeys }
+}
+
+export async function loadLocaleDictionaries(localesDirectory = defaultLocalesDir) {
+  const files = readdirSync(localesDirectory).filter(file => file.endsWith('.js')).sort()
+  const dictionaries = new Map()
+  const errors = []
+  for (const file of files) {
+    const locale = file.replace(/\.js$/, '')
+    try {
+      const { default: dictionary } = await import(pathToFileURL(join(localesDirectory, file)).href)
+      if (!dictionary || typeof dictionary !== 'object' || Array.isArray(dictionary)) {
+        errors.push(`${file}: no default-exported object`)
+      } else dictionaries.set(locale, dictionary)
+    } catch (error) {
+      errors.push(`${file}: failed to load (${error.message})`)
+    }
+  }
+  return { files, dictionaries, errors }
+}
+
+export async function runCheck({ localesDirectory = defaultLocalesDir, sourceDirectory = defaultSourceDir, sourceKeyExceptions = BASELINE_SOURCE_KEY_EXCEPTIONS } = {}) {
+  const loaded = await loadLocaleDictionaries(localesDirectory)
+  const sourceInventory = collectSourceInventory(sourceDirectory)
+  const actualLocales = new Set(loaded.dictionaries.keys())
+  const localeErrors = [
+    ...EXPECTED_LOCALES.filter(locale => !actualLocales.has(locale)).map(locale => `Missing expected locale pack: ${locale}.js`),
+    ...[...actualLocales].filter(locale => !EXPECTED_LOCALES.includes(locale)).map(locale => `Unexpected locale pack: ${locale}.js`),
+    ...loaded.errors
+  ]
+  const result = validateLocaleDictionaries({ dictionaries: loaded.dictionaries, sourceInventory, sourceKeyExceptions })
+  result.errors.unshift(...localeErrors)
+  result.failed = result.errors.length > 0
+  result.locales = loaded.dictionaries
+  return result
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))
+if (isMain) {
+  const result = await runCheck()
+  if (result.failed) {
+    for (const error of result.errors) console.error(error)
+    console.error('\nLocale inventory check failed. Every source key must be present, nonblank, and placeholder-safe in every locale.')
+    process.exitCode = 1
+  } else {
+    console.log(`${result.locales.size} locales, ${result.union.size} keys each — in sync with ${result.checkedSourceKeys} checked source t() keys (${result.sourceKeys - result.checkedSourceKeys} documented baseline exceptions).`)
+  }
+}

--- a/frontend/src/components/Modals.jsx
+++ b/frontend/src/components/Modals.jsx
@@ -35,6 +35,23 @@ function Sheet({ sheet }) {
     else el.style.transform = ''
     d.startY = null
   }
+  // Mouse drag (desktop testing / trackpads): same swipe-to-dismiss behaviour.
+  const onMouseDown = e => {
+    if (e.button !== 0) return
+    const el = ref.current
+    drag.current = { startY: el.scrollTop <= 0 ? e.clientY : null, delta: 0 }
+  }
+  const onMouseMove = e => {
+    const el = ref.current, d = drag.current
+    if (d.startY === null) return
+    d.delta = e.clientY - d.startY
+    if (d.delta > 0 && el.scrollTop <= 0) {
+      e.preventDefault()
+      el.style.transition = 'none'
+      el.style.transform = `translateY(${d.delta}px)`
+    } else d.delta = 0
+  }
+  const onMouseUp = () => onTouchEnd()
 
   // non-passive touchmove so preventDefault works (bottom sheets only; centered dialogs have no ref)
   useEffect(() => {
@@ -56,7 +73,8 @@ function Sheet({ sheet }) {
   return (
     <div>
       <div className="mback" onClick={() => { if (!sheet.locked) close() }} />
-      <div className="sheet" ref={ref} onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
+      <div className="sheet" ref={ref} onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}
+        onMouseDown={onMouseDown} onMouseMove={onMouseMove} onMouseUp={onMouseUp}>
         <div className="grab" />
         {sheet.render(close)}
       </div>
@@ -66,8 +84,48 @@ function Sheet({ sheet }) {
 
 export default function Modals() {
   const sheets = useUI(s => s.sheets)
+  const closeSheet = useUI(s => s.closeSheet)
+  const prevLen = useRef(0)
+  const backClosed = useRef(false)
+  const suppressPop = useRef(false)
+
+  // Every open sheet gets a history entry so the Android back button dismisses it
+  // instead of leaving the page (issue #63). A normal close pops its entry again.
+  useEffect(() => {
+    const prev = prevLen.current
+    prevLen.current = sheets.length
+    if (sheets.length > prev) {
+      history.pushState({ openGymSheet: true }, '')
+    } else if (sheets.length < prev) {
+      if (backClosed.current) {
+        backClosed.current = false
+      } else if (sheets.length === 0) {
+        suppressPop.current = true
+        history.go(-prev)
+      } else {
+        suppressPop.current = true
+        history.back()
+      }
+    }
+  }, [sheets.length])
+
+  useEffect(() => {
+    const onPop = () => {
+      if (suppressPop.current) { suppressPop.current = false; return }
+      const top = sheets[sheets.length - 1]
+      if (top && !top.locked) { backClosed.current = true; closeSheet(top.id) }
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [sheets, closeSheet])
 
   // lock the page behind any open sheet (iOS-safe)
+  useEffect(() => {
+    if (!sheets.length) return
+    const onKey = e => { if (e.key === 'Escape') { const top = useUI.getState().sheets[useUI.getState().sheets.length - 1]; if (top && !top.locked) useUI.getState().closeSheet(top.id) } }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [sheets.length])
   useEffect(() => {
     if (!sheets.length) return
     const y = window.scrollY || 0

--- a/frontend/src/components/TabBar.jsx
+++ b/frontend/src/components/TabBar.jsx
@@ -3,6 +3,7 @@ import { useStore } from '../store/useStore.js'
 import { effectiveRoutines } from '../lib/history.js'
 import { todayISO } from '../lib/format.js'
 import { t } from '../lib/i18n.js'
+import { startSessionSheet } from '../sheets.jsx'
 import Icon from './Icon.jsx'
 
 export default function TabBar({ onStart }) {
@@ -19,6 +20,7 @@ export default function TabBar({ onStart }) {
     if (!S.active) {
       const plans = effectiveRoutines(S, todayISO())
       if (plans.length === 1 && plans[0].ex.length) { onStart(plans[0].id); return }
+      if (plans.length > 1) { startSessionSheet(); return }
     }
     nav('/workout')
   }

--- a/frontend/src/components/TabBar.jsx
+++ b/frontend/src/components/TabBar.jsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
-import { effectiveRoutine } from '../lib/history.js'
+import { effectiveRoutines } from '../lib/history.js'
 import { todayISO } from '../lib/format.js'
 import { t } from '../lib/i18n.js'
 import Icon from './Icon.jsx'
@@ -17,8 +17,8 @@ export default function TabBar({ onStart }) {
 
   const startWorkout = () => {
     if (!S.active) {
-      const r = effectiveRoutine(S, todayISO())
-      if (r && r.ex.length) { onStart(r.id); return }
+      const plans = effectiveRoutines(S, todayISO())
+      if (plans.length === 1 && plans[0].ex.length) { onStart(plans[0].id); return }
     }
     nav('/workout')
   }

--- a/frontend/src/components/TabBar.jsx
+++ b/frontend/src/components/TabBar.jsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
-import { effectiveRoutines } from '../lib/history.js'
+import { effectiveRoutines, completedRoutineIdsForDate, reconcileStartSessionChoice } from '../lib/history.js'
 import { todayISO } from '../lib/format.js'
 import { t } from '../lib/i18n.js'
 import { startSessionSheet } from '../sheets.jsx'
@@ -15,12 +15,14 @@ export default function TabBar({ onStart }) {
   if (!user && !isGuest) return null
   const cur = loc.pathname.split('/')[1] || 'home'
   const on = k => cur === k || (cur === 'history' && k === 'stats') || (cur === 'settings' && k === 'home')
+  const todayPlans = effectiveRoutines(S, todayISO())
+  const doneToday = completedRoutineIdsForDate(S, todayISO())
+  const openRoutineId = reconcileStartSessionChoice(todayPlans, doneToday, null)
 
   const startWorkout = () => {
     if (!S.active) {
-      const plans = effectiveRoutines(S, todayISO())
-      if (plans.length === 1 && plans[0].ex.length) { onStart(plans[0].id); return }
-      if (plans.length > 1) { startSessionSheet(); return }
+      if (todayPlans.length === 1 && openRoutineId && todayPlans[0].ex.length) { onStart(openRoutineId); return }
+      if (todayPlans.length > 1 || (todayPlans.length === 1 && !openRoutineId)) { startSessionSheet(); return }
     }
     nav('/workout')
   }
@@ -36,7 +38,7 @@ export default function TabBar({ onStart }) {
       <Tab k="plan" icon="calendar" to="/plan" label={t('Plan')} />
       <button className={'start' + (S.active ? ' rec' : '')} onClick={startWorkout}>
         <span className="cir"><Icon name={S.active ? 'play' : 'dumbbell'} /></span>
-        <span>{S.active ? t('Resume') : t('Start')}</span>
+        <span>{S.active ? t('Resume') : todayPlans.length && !openRoutineId ? t('Done') : t('Start')}</span>
       </button>
       <Tab k="stats" icon="chart" to="/stats" label={t('Stats')} />
       <Tab k="library" icon="list" to="/library" label={t('Exercises')} />

--- a/frontend/src/lib/demoSeed.js
+++ b/frontend/src/lib/demoSeed.js
@@ -145,7 +145,7 @@ export function buildDemoState() {
   if (!byWeekday[today.getDay()] && !workouts.some(w => w.d === tIso)) {
     const order = [push, pull, legs]
     const lastName = workouts.length ? workouts[workouts.length - 1].name : legs.name
-    dayPlan[tIso] = order[(order.findIndex(r => r.name === lastName) + 1) % order.length].id
+    dayPlan[tIso] = [order[(order.findIndex(r => r.name === lastName) + 1) % order.length].id]
   }
 
   return {

--- a/frontend/src/lib/effort.js
+++ b/frontend/src/lib/effort.js
@@ -6,7 +6,7 @@
 // half-empty series. So everything aggregates in RIR and is converted back for display.
 // RIR is the internal unit because it has a real zero — a set taken to failure — where RPE's
 // floor of 6 is only a convention about which sets are worth rating. RPE 8 == RIR 2.
-import { EFFORT, effortOf } from './history.js'
+import { EFFORT, effortOf, isWarmupRow } from './history.js'
 import { weekKey } from './format.js'
 
 // At or below this a set is close enough to failure to be the kind that drives adaptation.
@@ -44,7 +44,7 @@ export const scaleName = kind => EFFORT[kind].hd
 function eachDoneSet(S, fn) {
   ;(S.workouts || []).forEach(w =>
     (w.entries || []).forEach(e =>
-      (e.sets || []).forEach(s => { if (s.done && !s.warmup) fn(s, w, e) })))
+      (e.sets || []).forEach(s => { if (s.done && !isWarmupRow(s)) fn(s, w, e) })))
 }
 
 // A window in days, counted back from now. 0 = everything, which is also what an empty

--- a/frontend/src/lib/effort.test.js
+++ b/frontend/src/lib/effort.test.js
@@ -173,3 +173,13 @@ describe('isHardSet', () => {
     expect(isHardSet({})).toBe(false)          // unrated is not hard, and not easy either
   })
 })
+
+describe('coverage with warm-up phases', () => {
+  it.each([
+    ['legacy boolean', { phase: 'work', warmup: true }],
+    ['explicit phase', { phase: 'warmup' }]
+  ])('excludes five completed %s warm-ups from effort aggregation', (_label, marker) => {
+    const r = effortSummary(S(W(2, Array.from({ length: 5 }, (_, i) => ({ ...marker, rir: i })))), 0)
+    expect(r).toEqual({ done: 0, rated: 0, hard: 0, avg: null, hardPct: null })
+  })
+})

--- a/frontend/src/lib/history.js
+++ b/frontend/src/lib/history.js
@@ -208,10 +208,11 @@ export function effectiveRoutineIds(S, iso) {
   if (asRoutineIds(raw).includes('rest')) return []
 
   const ids = validRoutineIds(S, raw)
-  if (ids.length || !hasOverride || Array.isArray(raw)) return ids
+  if (ids.length || !hasOverride || (Array.isArray(raw) && raw.length === 0)) return ids
 
-  // Preserve the old scalar helper's behavior for a stale/unknown override: fall back to the
-  // weekly routine rather than turning a bad id into an unexpected rest day.
+  // Preserve the old helper's behavior for a stale/unknown override: fall back to the weekly
+  // routine rather than turning a bad legacy id into an unexpected rest day. Empty arrays remain
+  // explicit rest overrides, while a list containing valid ids already returned above.
   return validRoutineIds(S, S?.week?.[wd])
 }
 

--- a/frontend/src/lib/history.js
+++ b/frontend/src/lib/history.js
@@ -177,16 +177,53 @@ export function bestWeightFor(S, exId) {
   }))
   return best
 }
-export function effectiveRoutineId(S, iso) {
-  const ov = S.dayPlan[iso]
-  if (ov === 'rest') return null
-  if (ov && S.routines.some(r => r.id === ov)) return ov
+// Day overrides used to be one routine id (or the special `rest` value). New writes use a
+// list, but every load path runs this copy-on-read normalizer so old backups and server state
+// become the new shape without changing callers that still hold an old object.
+export function normalizeDayPlan(S) {
+  if (!S || !S.dayPlan || typeof S.dayPlan !== 'object' || Array.isArray(S.dayPlan)) return S
+  const dayPlan = {}
+  Object.entries(S.dayPlan).forEach(([iso, value]) => {
+    dayPlan[iso] = Array.isArray(value) ? value.slice() : [value]
+  })
+  return { ...S, dayPlan }
+}
+
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key)
+const asRoutineIds = value => Array.isArray(value) ? value : value == null || value === '' ? [] : [value]
+const knownRoutineIds = S => new Set((S?.routines || []).map(r => r.id))
+const validRoutineIds = (S, value) => {
+  const known = knownRoutineIds(S)
+  return [...new Set(asRoutineIds(value).filter(id => id && id !== 'rest' && known.has(id)))]
+}
+
+// All routines effective for a day, in the order stored by the plan. `week` deliberately stays
+// scalar: it is the recurring fallback, while a date override can add morning + evening plans.
+// A `rest` override is exclusive, and an empty list is the same explicit no-plan override.
+export function effectiveRoutineIds(S, iso) {
+  const dayPlan = S?.dayPlan || {}
+  const hasOverride = hasOwn(dayPlan, iso)
   const wd = new Date(iso + 'T12:00:00').getDay()
-  return S.week[wd] || null
+  const raw = hasOverride ? dayPlan[iso] : S?.week?.[wd]
+  if (asRoutineIds(raw).includes('rest')) return []
+
+  const ids = validRoutineIds(S, raw)
+  if (ids.length || !hasOverride || Array.isArray(raw)) return ids
+
+  // Preserve the old scalar helper's behavior for a stale/unknown override: fall back to the
+  // weekly routine rather than turning a bad id into an unexpected rest day.
+  return validRoutineIds(S, S?.week?.[wd])
+}
+
+export function effectiveRoutineId(S, iso) {
+  return effectiveRoutineIds(S, iso)[0] || null
+}
+export function effectiveRoutines(S, iso) {
+  const routines = new Map((S?.routines || []).map(r => [r.id, r]))
+  return effectiveRoutineIds(S, iso).map(id => routines.get(id)).filter(Boolean)
 }
 export function effectiveRoutine(S, iso) {
-  const id = effectiveRoutineId(S, iso)
-  return id ? S.routines.find(r => r.id === id) || null : null
+  return effectiveRoutines(S, iso)[0] || null
 }
 export function buildSets(S, cfg, options = {}) {
   const last = lastEntryFor(S, cfg.id)

--- a/frontend/src/lib/history.js
+++ b/frontend/src/lib/history.js
@@ -22,6 +22,12 @@ export function modeOf(cfg) {
 }
 export const isTimed = cfg => modeOf(cfg) === 'time'
 
+// Warm-up markers exist in both the legacy boolean shape and the newer explicit phase shape.
+// Keep the boundary here so history, statistics, import, and UI callers cannot disagree about
+// whether a completed row is working data. Unannotated rows remain work rows for compatibility.
+export const isWarmupRow = row => row?.warmup === true || row?.phase === 'warmup'
+export const isWorkRow = row => !isWarmupRow(row)
+
 // Two flags that ride on top of a mode rather than making new ones (issues #31/#32), because
 // "bodyweight" and "per side" are true of a rep set and of a timed hold alike:
 //   bodyweight — the exercise carries no load of its own, so `w` means *added* weight and is
@@ -147,8 +153,10 @@ export function lastEntryFor(S, exId) {
     const en = S.workouts[i].entries.find(e => e.id === exId)
     // `target` is what the session prescribed; finished workouts carry it so labels and the
     // progression engine can read a session back the way it was logged. Older workouts have
-    // none — modeOf() falls back to the body part for them, which is what they were.
-    if (en && en.sets.some(s => s.done)) return { d: S.workouts[i].d, sets: en.sets.filter(s => s.done), target: en.target || null }
+    // none — modeOf() falls back to the body part for them, which is what they were. Warm-ups
+    // are deliberately excluded: they must not seed a later working prescription.
+    const sets = en?.sets?.filter(s => s.done && isWorkRow(s)) || []
+    if (sets.length) return { d: S.workouts[i].d, sets, target: en.target || null }
   }
   return null
 }
@@ -171,8 +179,23 @@ export function bestWeightFor(S, exId) {
   let best = 0
   S.workouts.forEach(w => w.entries.forEach(e => {
     if (e.id === exId) {
-      e.sets.forEach(s => { if (s.done && s.w > best) best = s.w })
-      if (e.topW && e.topW > best) best = e.topW
+      const modeForSet = s => modeOf({ ...(e.target || {}), ...s, id: e.id })
+      let hasRepsWork = false
+      let hasNonRepsWork = false
+      e.sets.forEach(s => {
+        if (!s.done || !isWorkRow(s)) return
+        if (modeForSet(s) !== 'reps') {
+          hasNonRepsWork = true
+          return
+        }
+        hasRepsWork = true
+        if (s.w > best) best = s.w
+      })
+      // topW has no row mode of its own. It is authoritative only when a completed reps row
+      // proves that the entry was a working-weight prescription. Mixed-mode entries and targets
+      // that are explicitly timed/cardio fail closed; do not infer reps from shape.
+      const parentMode = modeOf({ ...(e.target || {}), id: e.id })
+      if (hasRepsWork && !hasNonRepsWork && parentMode === 'reps' && e.topW > best) best = e.topW
     }
   }))
   return best
@@ -181,12 +204,12 @@ export function bestWeightFor(S, exId) {
 // list, but every load path runs this copy-on-read normalizer so old backups and server state
 // become the new shape without changing callers that still hold an old object.
 export function normalizeDayPlan(S) {
-  if (!S || !S.dayPlan || typeof S.dayPlan !== 'object' || Array.isArray(S.dayPlan)) return S
-  const dayPlan = {}
-  Object.entries(S.dayPlan).forEach(([iso, value]) => {
-    dayPlan[iso] = Array.isArray(value) ? value.slice() : [value]
-  })
-  return { ...S, dayPlan }
+  const source = S && typeof S === 'object' && !Array.isArray(S) ? S : {}
+  const raw = source.dayPlan
+  const dayPlan = raw && typeof raw === 'object' && !Array.isArray(raw)
+    ? Object.fromEntries(Object.entries(raw).map(([iso, value]) => [iso, Array.isArray(value) ? value.slice() : [value]]))
+    : {}
+  return { ...source, dayPlan }
 }
 
 const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key)
@@ -226,6 +249,27 @@ export function effectiveRoutines(S, iso) {
 export function effectiveRoutine(S, iso) {
   return effectiveRoutines(S, iso)[0] || null
 }
+
+// A planned session is complete for a local calendar date as soon as a workout carrying its
+// routine id is recorded on that date. Keep this date/routine contract in one place so every
+// start surface agrees about whether its fast-path is still safe.
+export function completedRoutineIdsForDate(S, iso) {
+  const done = new Set()
+  ;(S?.workouts || []).forEach(w => {
+    if (String(w?.d || '').slice(0, 10) === iso && w?.routineId) done.add(w.routineId)
+  })
+  return done
+}
+
+// Return the selected routine only while it remains open; stale selections fall forward to the
+// first uncompleted plan. A null result means the caller must show an explicit choose-another or
+// freestyle path rather than silently starting a completed plan.
+export function reconcileStartSessionChoice(todayPlans, doneToday, chosen) {
+  const selectedIsOpen = chosen && todayPlans.some(r => r.id === chosen && !doneToday.has(r.id))
+  if (selectedIsOpen) return chosen
+  return todayPlans.find(r => !doneToday.has(r.id))?.id || null
+}
+
 export function buildSets(S, cfg, options = {}) {
   const last = lastEntryFor(S, cfg.id)
   const n = Math.max(1, cfg.sets || 1)
@@ -267,7 +311,7 @@ export function workoutVolume(w) {
   let v = 0
   // No special case for unilateral work: a per-side set logs its total, so both sides are
   // already in the rep count that arrives here.
-  w.entries.forEach(e => e.sets.forEach(s => { if (s.done) v += (s.w || 0) * (s.r || 0) }))
+  w.entries.forEach(e => e.sets.forEach(s => { if (s.done && isWorkRow(s)) v += (s.w || 0) * (s.r || 0) }))
   return v
 }
 export function setsDone(w) {
@@ -310,14 +354,14 @@ export function streakWeeks(S) {
 }
 
 /**
- * Cascade a weight change forward: following sets of the same warm-up flag that are still
+ * Cascade a weight change forward: following sets in the same canonical phase that are still
  * undone take the new value (null deletes the key). Done sets are never rewritten.
  */
 export function cascadeWeight(rows, from, value) {
-  const warm = !!rows[from]?.warmup
+  const warm = isWarmupRow(rows[from])
   const next = rows.slice()
   for (let j = from + 1; j < next.length; j++) {
-    if (!!next[j].warmup === warm && !next[j].done) {
+    if (isWarmupRow(next[j]) === warm && !next[j].done) {
       if (value == null) delete next[j].w
       else next[j].w = value
     }
@@ -327,7 +371,7 @@ export function cascadeWeight(rows, from, value) {
 
 /** Insert a warm-up row before the first work row, copying the preceding warm-up's values. */
 export function insertWarmupRow(rows, mode, target) {
-  const firstWork = rows.findIndex(x => !x.warmup)
+  const firstWork = rows.findIndex(isWorkRow)
   const at = firstWork === -1 ? rows.length : firstWork
   const l = rows[at - 1] || rows[rows.length - 1]
   const warm = mode === 'cardio'
@@ -351,6 +395,6 @@ export function removeRowAt(rows, i) {
 /** Completed non-warm-up sets across a workout's entries. */
 export function workSetsDone(w) {
   return (w?.entries || []).reduce(
-    (n, e) => n + (e.sets || []).filter(s => s.done && !s.warmup).length, 0,
+    (n, e) => n + (e.sets || []).filter(s => s.done && isWorkRow(s)).length, 0,
   )
 }

--- a/frontend/src/lib/history.test.js
+++ b/frontend/src/lib/history.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { modeOf, isTimed, fmtSec, setLabel, defaultConfig, buildSets, freestyleConfig, exLine, workoutVolume, effortOf, stepEffort, capEffort, isBw, isPerSide, sideReps, repStep, cascadeWeight, insertWarmupRow, removeRowAt } from './history.js'
+import { modeOf, isTimed, fmtSec, setLabel, defaultConfig, buildSets, freestyleConfig, exLine, workoutVolume, effortOf, stepEffort, capEffort, isBw, isPerSide, sideReps, repStep, cascadeWeight, insertWarmupRow, removeRowAt, effectiveRoutineIds, effectiveRoutineId, normalizeDayPlan } from './history.js'
 import { EXDB } from './exercises.js'
 
 // Real ids out of the shipped catalogue, so the body-part fallback is exercised for real.
@@ -527,5 +527,44 @@ describe('session row helpers', () => {
     const next = removeRowAt(rows, 0)
     expect(next.length).toBe(1)
     expect(next[0].w).toBe(70)
+
+describe('multiple plans per day', () => {
+  const routines = [{ id: 'morning' }, { id: 'evening' }, { id: 'weekly' }]
+  const monday = '2026-01-05'
+
+  it('migrates a legacy scalar override to a list without mutating the loaded object', () => {
+    const state = { dayPlan: { [monday]: 'morning' } }
+    const migrated = normalizeDayPlan(state)
+
+    expect(migrated).not.toBe(state)
+    expect(migrated.dayPlan).toEqual({ [monday]: ['morning'] })
+    expect(state.dayPlan[monday]).toBe('morning')
+  })
+
+  it('keeps legacy scalar overrides and rest overrides effective', () => {
+    const legacy = { routines, week: { 1: 'weekly' }, dayPlan: { [monday]: 'morning' } }
+    const rest = { routines, week: { 1: 'weekly' }, dayPlan: { [monday]: 'rest' } }
+
+    expect(effectiveRoutineIds(legacy, monday)).toEqual(['morning'])
+    expect(effectiveRoutineId(legacy, monday)).toBe('morning')
+    expect(effectiveRoutineIds(rest, monday)).toEqual([])
+    expect(effectiveRoutineId(rest, monday)).toBe(null)
+  })
+
+  it('returns every valid routine in a multi-plan override in stored order', () => {
+    const state = {
+      routines,
+      week: { 1: 'weekly' },
+      dayPlan: { [monday]: ['evening', 'morning', 'evening', 'missing'] }
+    }
+
+    expect(effectiveRoutineIds(state, monday)).toEqual(['evening', 'morning'])
+    expect(effectiveRoutineId(state, monday)).toBe('evening')
+  })
+
+  it('falls back to the weekly plan when there is no date override', () => {
+    const state = { routines, week: { 1: 'weekly' }, dayPlan: {} }
+    expect(effectiveRoutineIds(state, monday)).toEqual(['weekly'])
+
   })
 })

--- a/frontend/src/lib/history.test.js
+++ b/frontend/src/lib/history.test.js
@@ -527,6 +527,8 @@ describe('session row helpers', () => {
     const next = removeRowAt(rows, 0)
     expect(next.length).toBe(1)
     expect(next[0].w).toBe(70)
+  })
+})
 
 describe('multiple plans per day', () => {
   const routines = [{ id: 'morning' }, { id: 'evening' }, { id: 'weekly' }]
@@ -549,6 +551,12 @@ describe('multiple plans per day', () => {
     expect(effectiveRoutineId(legacy, monday)).toBe('morning')
     expect(effectiveRoutineIds(rest, monday)).toEqual([])
     expect(effectiveRoutineId(rest, monday)).toBe(null)
+  })
+
+  it('keeps the weekly fallback for a stale legacy override after read migration', () => {
+    const state = normalizeDayPlan({ routines, week: { 1: 'weekly' }, dayPlan: { [monday]: 'missing' } })
+
+    expect(effectiveRoutineIds(state, monday)).toEqual(['weekly'])
   })
 
   it('returns every valid routine in a multi-plan override in stored order', () => {

--- a/frontend/src/lib/history.test.js
+++ b/frontend/src/lib/history.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { modeOf, isTimed, fmtSec, setLabel, defaultConfig, buildSets, freestyleConfig, exLine, workoutVolume, effortOf, stepEffort, capEffort, isBw, isPerSide, sideReps, repStep, cascadeWeight, insertWarmupRow, removeRowAt, effectiveRoutineIds, effectiveRoutineId, normalizeDayPlan } from './history.js'
+import { modeOf, isTimed, fmtSec, setLabel, defaultConfig, buildSets, freestyleConfig, exLine, workoutVolume, effortOf, stepEffort, capEffort, isBw, isPerSide, sideReps, repStep, cascadeWeight, insertWarmupRow, removeRowAt, effectiveRoutineIds, effectiveRoutineId, normalizeDayPlan, lastEntryFor, bestWeightFor, workSetsDone, isWarmupRow, isWorkRow, completedRoutineIdsForDate, reconcileStartSessionChoice } from './history.js'
 import { EXDB } from './exercises.js'
 
 // Real ids out of the shipped catalogue, so the body-part fallback is exercised for real.
@@ -336,6 +336,84 @@ describe('exLine', () => {
 
 const emptyS = { workouts: [], exWeights: {} }
 
+describe('history builders share the non-warm-up work boundary', () => {
+  const makeState = warmup => ({ unit: 'kg', exWeights: {}, workouts: [{
+    d: '2026-03-01', unit: 'kg', entries: [{
+      id: LIFT, unit: 'kg', target: { mode: 'reps', sets: 2, reps: 5, weight: 60, unit: 'kg' },
+      sets: [
+        { unit: 'kg', w: 20, r: 8, mode: 'reps', done: true, ...warmup },
+        { unit: 'kg', w: 60, r: 5, mode: 'reps', done: true },
+        { unit: 'kg', w: 60, r: 5, mode: 'reps', done: true }
+      ]
+    }]
+  }] })
+
+  it.each([
+    ['legacy boolean', { warmup: true }],
+    ['explicit phase', { phase: 'warmup' }]
+  ])('excludes the %s warm-up from lastEntryFor, buildSets, and freestyleConfig', (_label, warmup) => {
+    const S = makeState(warmup)
+    expect(lastEntryFor(S, LIFT, 'reps').sets.map(set => set.w)).toEqual([60, 60])
+    expect(buildSets(S, { id: LIFT, mode: 'reps', sets: 2, reps: 5, weight: 0 }))
+      .toEqual([{ w: 60, r: 5, done: false }, { w: 60, r: 5, done: false }])
+    expect(freestyleConfig(S, { id: LIFT, mode: 'reps', sets: 1, reps: 3, weight: 0 }))
+      .toMatchObject({ sets: 2, reps: 5, weight: 60 })
+  })
+
+  it('does not treat a warm-up-only history row as a completed work session', () => {
+    for (const warmup of [{ warmup: true }, { phase: 'warmup' }]) {
+      const S = { unit: 'kg', exWeights: {}, workouts: [{
+        d: '2026-03-02', unit: 'kg', entries: [{ id: LIFT, unit: 'kg', target: { mode: 'reps', sets: 1, reps: 5, weight: 50, unit: 'kg' }, sets: [
+          { unit: 'kg', w: 20, r: 8, mode: 'reps', done: true, ...warmup }
+        ] }]
+      }] }
+      expect(lastEntryFor(S, LIFT, 'reps')).toBeNull()
+      expect(freestyleConfig(S, { id: LIFT, mode: 'reps', sets: 1, reps: 5, weight: 50 }))
+        .toMatchObject({ sets: 1, reps: 5, weight: 50 })
+    }
+  })
+})
+
+describe('workSetsDone shares the non-warm-up work boundary', () => {
+  it.each([
+    ['legacy boolean', { phase: 'work', warmup: true }],
+    ['explicit phase', { phase: 'warmup' }]
+  ])('excludes a completed %s warm-up', (_label, marker) => {
+    const workout = { entries: [{ sets: [
+      { ...marker, done: true },
+      { phase: 'work', done: true }
+    ] }] }
+    expect(workSetsDone(workout)).toBe(1)
+  })
+})
+
+describe('bestWeightFor preserves explicit row modes', () => {
+  it('rejects an unannotated rep-shaped row under a timed target', () => {
+    const S = { workouts: [{ entries: [{ id: LIFT, target: { mode: 'time' }, topW: 200, sets: [{ w: 100, r: 5, done: true }] }] }] }
+    expect(bestWeightFor(S, LIFT)).toBe(0)
+  })
+
+  it('accepts an authoritative completed reps row under a timed target', () => {
+    const S = { workouts: [{ entries: [{ id: LIFT, target: { mode: 'time' }, topW: 200, sets: [{ mode: 'reps', w: 100, r: 5, done: true }] }] }] }
+    expect(bestWeightFor(S, LIFT)).toBe(100)
+  })
+})
+
+describe('cascadeWeight shares the canonical warm-up boundary', () => {
+  it.each([
+    ['legacy boolean', { phase: 'work', warmup: true }],
+    ['explicit phase', { phase: 'warmup' }]
+  ])('does not cascade a warm-up change into work rows for %s rows', (_label, marker) => {
+    const rows = [
+      { ...marker, w: 20, done: false },
+      { ...marker, w: 22, done: false },
+      { phase: 'work', w: 60, done: false },
+      { phase: 'work', w: 70, done: true }
+    ]
+    expect(cascadeWeight(rows, 0, 30).map(row => row.w)).toEqual([20, 30, 60, 70])
+  })
+})
+
 describe('freestyleConfig', () => {
   it('inherits the last target and completed set count for a newly added exercise', () => {
     const S = {
@@ -573,6 +651,21 @@ describe('multiple plans per day', () => {
   it('falls back to the weekly plan when there is no date override', () => {
     const state = { routines, week: { 1: 'weekly' }, dayPlan: {} }
     expect(effectiveRoutineIds(state, monday)).toEqual(['weekly'])
+  })
 
+  it('deduplicates completed routine ids by the local workout date', () => {
+    const S = { workouts: [
+      { d: '2026-01-05T08:00:00.000Z', routineId: 'morning' },
+      { d: '2026-01-05', routineId: 'morning' },
+      { d: '2026-01-04T23:59:59.000Z', routineId: 'evening' },
+      { d: '2026-01-05', routineId: null }
+    ] }
+    expect(completedRoutineIdsForDate(S, monday)).toEqual(new Set(['morning']))
+  })
+
+  it('reconciles a stale selection to the first open plan and fails closed when all are done', () => {
+    expect(reconcileStartSessionChoice(routines.slice(0, 2), new Set(), null)).toBe('morning')
+    expect(reconcileStartSessionChoice(routines.slice(0, 2), new Set(['morning']), 'morning')).toBe('evening')
+    expect(reconcileStartSessionChoice(routines.slice(0, 2), new Set(['morning', 'evening']), 'evening')).toBeNull()
   })
 })

--- a/frontend/src/lib/import-csv.js
+++ b/frontend/src/lib/import-csv.js
@@ -20,6 +20,7 @@
 
 import { EXDB, EXIDX } from './exercises.js'
 import { uid } from './format.js'
+import { modeOf, isWorkRow } from './history.js'
 
 /* ----------------------------------------------------------------- CSV ---- */
 
@@ -334,7 +335,8 @@ export function parseWorkoutCSV(text, { unit = 'kg' } = {}) {
       ? num(cell(r, 'distanceKm'))
       : toKm(cell(r, 'distance'), cell(r, 'distanceUnit'))
     if (!w && !reps && !mins && !km) { skipped++; continue }
-    if (/warm/i.test(cell(r, 'setType'))) warmups++
+    const warmup = /warm/i.test(cell(r, 'setType'))
+    if (warmup) warmups++
 
     const key = keyOf(name)
     let id = resolved.get(key)
@@ -358,7 +360,7 @@ export function parseWorkoutCSV(text, { unit = 'kg' } = {}) {
     // it never reaches the stored set.
     const set = isCardio
       ? { min: mins || 0, speed: mins > 0 ? Math.round(km / (mins / 60) * 10) / 10 : 0, done: true }
-      : { w, r: reps || 0, done: true, u: rowUnit }
+      : { w, r: reps || 0, done: true, u: rowUnit, ...(warmup ? { warmup: true } : {}) }
     // Effort rides along only where the app can show it again: a weighted rep set. A treadmill
     // row with an RPE would have nowhere to put it. A set is kept on one scale, so a file
     // carrying both columns is read as RIR — the same precedence setLabel reads them back with.
@@ -405,7 +407,9 @@ export function parseWorkoutCSV(text, { unit = 'kg' } = {}) {
     const day = byDate.get(d)
     const entries = [...day.ex.entries()].map(([id, ss]) => {
       const conv2 = ss.map(({ u, ...s }) => (s.w !== undefined ? { ...s, w: convRow({ ...s, u }) } : s))
-      const mx = Math.max(0, ...conv2.map(s => s.w || 0))
+      const mx = Math.max(0, ...conv2
+        .filter(s => isWorkRow(s) && modeOf({ id }) === 'reps')
+        .map(s => s.w || 0))
       return { id, sets: conv2, topW: mx || null }
     })
     const base = new Date(d + 'T00:00:00').getTime()
@@ -415,7 +419,7 @@ export function parseWorkoutCSV(text, { unit = 'kg' } = {}) {
       id: 'iw' + uid(), d, start, end: end > start ? end : start,
       routineId: null, name: day.name || 'Imported', entries, prs: [],
     }
-    w.vol = entries.reduce((a, e) => a + e.sets.reduce((b, s) => b + (s.w || 0) * (s.r || 0), 0), 0)
+    w.vol = entries.reduce((a, e) => a + e.sets.reduce((b, s) => b + (isWorkRow(s) ? (s.w || 0) * (s.r || 0) : 0), 0), 0)
     return w
   })
 
@@ -519,7 +523,8 @@ export function mergeImport(S, parsed) {
   S.workouts = [...S.workouts, ...fresh].sort((a, b) => (a.d < b.d ? -1 : 1))
   // seed the weight suggestions from the newest imported set of each lift
   fresh.forEach(w => w.entries.forEach(e => {
-    const mx = Math.max(0, ...e.sets.map(s => s.w || 0), e.topW || 0)
+    const workSets = e.sets.filter(s => isWorkRow(s) && modeOf({ id: e.id }) === 'reps')
+    const mx = Math.max(0, ...workSets.map(s => s.w || 0), e.topW || 0)
     if (mx > 0) { const cur = S.exWeights[e.id]; if (!cur || w.d >= cur.d) S.exWeights[e.id] = { w: mx, d: w.d } }
   }))
   return { added: fresh.length, skipped: parsed.workouts.length - fresh.length }

--- a/frontend/src/lib/muscles.js
+++ b/frontend/src/lib/muscles.js
@@ -10,6 +10,9 @@
 import { EXIDX } from './exercises.js'
 import { isWorkRow } from './history.js'
 
+// R1+R2 use the shared work-row boundary: an explicit phase warm-up must not count as
+// muscle-load work merely because the legacy boolean marker is absent.
+
 // The muscles a map can shade, in head-to-toe order — also the order of any list
 // built from them, so "what am I neglecting" reads top-down like a body.
 export const MUSCLES = [

--- a/frontend/src/lib/muscles.js
+++ b/frontend/src/lib/muscles.js
@@ -8,6 +8,7 @@
 // ankles, "cardiovascular system") maps to null and is dropped rather than guessed at.
 
 import { EXIDX } from './exercises.js'
+import { isWorkRow } from './history.js'
 
 // The muscles a map can shade, in head-to-toe order — also the order of any list
 // built from them, so "what am I neglecting" reads top-down like a body.
@@ -108,7 +109,7 @@ export function loadOf(items) {
  */
 export const loadOfWorkouts = (workouts, pick) =>
   loadOf((workouts || []).flatMap(w =>
-    (w.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && !s.warmup && (!pick || pick(s))).length }))))
+    (w.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && isWorkRow(s) && (!pick || pick(s))).length }))))
 
 /** Load a routine *would* produce, from its planned set counts. */
 export const loadOfRoutine = routine =>
@@ -116,7 +117,7 @@ export const loadOfRoutine = routine =>
 
 /** Load for a workout still in progress — the sets ticked so far. */
 export const loadOfActive = active =>
-  loadOf((active?.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && !s.warmup).length })))
+  loadOf((active?.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && isWorkRow(s)).length })))
 
 /**
  * Shade buckets 0–4 per muscle.

--- a/frontend/src/lib/onerm.js
+++ b/frontend/src/lib/onerm.js
@@ -9,6 +9,8 @@
 // one most lifters have seen; all of them agree closely at low reps and diverge as reps rise,
 // which is exactly why REP_CAP exists.
 
+import { modeOf, isWorkRow } from './history.js'
+
 // Above this many reps an estimate says more about work capacity than about maximal strength,
 // and the formulas disagree by double digits. Refusing to guess beats printing a fantasy.
 export const REP_CAP = 12
@@ -42,9 +44,15 @@ export function estimate1RM(w, r, formula = DEFAULT_FORMULA) {
 // `topW` is ignored on purpose: it records the working weight a user confirmed after the
 // exercise, with no rep count attached, so it cannot produce an estimate.
 export function bestSetOf(entry, formula = DEFAULT_FORMULA) {
+  const target = entry?.target || entry || {}
+  const modeForSet = set => modeOf({ ...target, ...set, id: entry?.id })
+  if (modeOf({ ...target, id: entry?.id }) !== 'reps') return null
+  const workModes = new Set((entry?.sets || []).filter(isWorkRow).map(modeForSet))
+  if (workModes.size !== 1 || !workModes.has('reps')) return null
+
   let best = null
   ;(entry?.sets || []).forEach(s => {
-    if (!s.done || s.warmup) return
+    if (!s.done || !isWorkRow(s) || modeForSet(s) !== 'reps') return
     const est = estimate1RM(s.w, s.r, formula)
     if (est !== null && (!best || est > best.est)) best = { est, w: Number(s.w), r: Math.round(Number(s.r)) }
   })

--- a/frontend/src/lib/onerm.test.js
+++ b/frontend/src/lib/onerm.test.js
@@ -77,6 +77,13 @@ describe('bestSetOf', () => {
     expect(bestSetOf(entry).w).toBe(100)
   })
 
+  it.each([
+    ['legacy boolean', { warmup: true }],
+    ['explicit phase', { phase: 'warmup' }]
+  ])('ignores completed %s rows', (_label, marker) => {
+    expect(bestSetOf({ id: 'x', sets: [{ ...marker, w: 200, r: 5, done: true }] })).toBeNull()
+  })
+
   it('ignores topW, which carries no rep count', () => {
     const entry = { id: 'x', topW: 200, sets: [{ w: 100, r: 5, done: true }] }
     expect(bestSetOf(entry).est).toBe(116.7)
@@ -86,6 +93,14 @@ describe('bestSetOf', () => {
     expect(bestSetOf({ id: 'c', sets: [{ min: 20, speed: 9, done: true }] })).toBeNull()
     expect(bestSetOf({ id: 'p', sets: [{ sec: 60, w: 0, done: true }] })).toBeNull()
     expect(bestSetOf({ id: 'p', sets: [{ sec: 60, w: 20, done: true }] })).toBeNull()
+  })
+
+  it('fails closed for target/row mixed modes', () => {
+    expect(bestSetOf({ id: 'x', target: { mode: 'time' }, sets: [{ mode: 'reps', w: 100, r: 5, done: true }] })).toBeNull()
+    expect(bestSetOf({ id: 'x', target: { mode: 'reps' }, sets: [
+      { mode: 'reps', w: 100, r: 5, done: true },
+      { mode: 'time', w: 100, sec: 60, done: true }
+    ] })).toBeNull()
   })
 
   it('survives a missing or empty entry', () => {

--- a/frontend/src/lib/progression.js
+++ b/frontend/src/lib/progression.js
@@ -19,6 +19,8 @@
 import { modeOf, repStep, isWarmupRow, isWorkRow } from './history.js'
 import { EXIDX } from './exercises.js'
 
+// Keep the R1+R2 warm-up semantics for both legacy boolean and explicit phase rows.
+
 export const POLICIES = ['off', 'linear', 'greyskull', 'double', 'time']
 
 // Which policies can sensibly drive which logging mode.

--- a/frontend/src/lib/progression.js
+++ b/frontend/src/lib/progression.js
@@ -16,7 +16,7 @@
 //   · fewer sets than prescribed                       → miss
 // So a session that fell apart can never advance the load as though it had succeeded.
 
-import { modeOf, repStep } from './history.js'
+import { modeOf, repStep, isWarmupRow, isWorkRow } from './history.js'
 import { EXIDX } from './exercises.js'
 
 export const POLICIES = ['off', 'linear', 'greyskull', 'double', 'time']
@@ -103,7 +103,7 @@ export function readSession(entry, fallback) {
   const mode = modeOf({ ...target, id: entry && entry.id })
   // Warm-up rows are prep, not the session: one filtered read beats guarding every consumer
   // below (an undone warm-up otherwise poisons `ok` forever and its reps drag `low`/`count`).
-  const sets = ((entry && entry.sets) || []).filter(s => !s.warmup)
+  const sets = ((entry && entry.sets) || []).filter(isWorkRow)
   const planned = target.sets || sets.length
   const enough = sets.length >= planned
 
@@ -134,7 +134,7 @@ export function sessionsFor(S, exId, fallback) {
   const out = []
   ;(S.workouts || []).forEach(w => {
     const entry = w.entries.find(e => e.id === exId)
-    if (entry && entry.sets.some(s => s.done && !s.warmup)) out.push({ d: w.d, ...readSession(entry, fallback) })
+    if (entry && entry.sets.some(s => s.done && isWorkRow(s))) out.push({ d: w.d, ...readSession(entry, fallback) })
   })
   return out
 }
@@ -255,7 +255,7 @@ export function applyPrescription(sets, p) {
     // Never rewrite a logged set, and never rewrite a warm-up: the prescription speaks to
     // the work rows only (a ticked warm-up falling through here would be the data-loss the
     // cascade fix removed, two files over).
-    if (s.done || s.warmup) return s
+    if (s.done || isWarmupRow(s)) return s
     const o = { ...s }
     if (p.weight != null) o.w = p.weight
     if (p.reps != null) o.r = p.reps
@@ -265,10 +265,10 @@ export function applyPrescription(sets, p) {
   // A policy that decided on a set count gets to grow the list — bodyweight progression adds
   // a set where a barbell would have added a plate. Only ever upwards, and only by copying a
   // row that is already there: a session in progress must not lose a set it has logged.
-  const workRows = out.filter(s => !s.warmup)
+  const workRows = out.filter(isWorkRow)
   if (p.sets > workRows.length) {
     const seed = workRows[workRows.length - 1] || out[out.length - 1]
-    while (out.filter(s => !s.warmup).length < p.sets) out.push({ ...seed, done: false })
+    while (out.filter(isWorkRow).length < p.sets) out.push({ ...seed, done: false })
   }
   return out
 }

--- a/frontend/src/locales/de.js
+++ b/frontend/src/locales/de.js
@@ -584,4 +584,7 @@ export default {
   '{0} per side': '{0} pro Seite',
   'You still log the total: {0} is {1} per side.': 'Du trägst weiterhin die Gesamtzahl ein: {0} sind {1} pro Seite.',
   '{0} sets · {1} work': '{0} Sätze · {1} Arbeit',
+  'Today’s sessions': 'Heutige Einheiten',
+  'Choose a session': 'Einheit wählen',
+  'Every planned session is done today — pick another routine or go freestyle.': 'Alle geplanten Einheiten sind heute erledigt — wähle eine andere Routine oder trainiere frei.'
 }

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} por lado',
   'You still log the total: {0} is {1} per side.': 'Sigues registrando el total: {0} son {1} por lado.',
   '{0} sets · {1} work': '{0} series · {1} trabajo',
+  'Today’s sessions': 'Sesiones de hoy',
+  'Choose a session': 'Elegir una sesión',
+  'Every planned session is done today — pick another routine or go freestyle.': 'Todas las sesiones previstas de hoy están hechas: elige otra rutina o entrena libre.'
 }

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} par côté',
   'You still log the total: {0} is {1} per side.': 'Tu notes toujours le total : {0}, c’est {1} par côté.',
   '{0} sets · {1} work': '{0} séries · {1} travail',
+  'Today’s sessions': 'Séances du jour',
+  'Choose a session': 'Choisir une séance',
+  'Every planned session is done today — pick another routine or go freestyle.': 'Toutes les séances prévues aujourd’hui sont faites — choisissez une autre routine ou entraînez-vous librement.'
 }

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': 'प्रति तरफ़ {0}',
   'You still log the total: {0} is {1} per side.': 'आप कुल ही दर्ज करते हैं: {0} यानी प्रति तरफ़ {1}।',
   '{0} sets · {1} work': '{0} सेट · {1} काम',
+  'Today’s sessions': 'आज के सेशन',
+  'Choose a session': 'सेशन चुनें',
+  'Every planned session is done today — pick another routine or go freestyle.': 'आज की सभी नियोजित सेशन पूरी हो चुकी हैं — कोई दूसरी रूटीन चुनें या फ्रीस्टाइल करें।'
 }

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} per lato',
   'You still log the total: {0} is {1} per side.': 'Registri sempre il totale: {0} sono {1} per lato.',
   '{0} sets · {1} work': '{0} serie · {1} lavoro',
+  'Today’s sessions': 'Sessioni di oggi',
+  'Choose a session': 'Scegli una sessione',
+  'Every planned session is done today — pick another routine or go freestyle.': 'Tutte le sessioni previste oggi sono completate: scegli un’altra routine o allenati libero.'
 }

--- a/frontend/src/locales/ko.js
+++ b/frontend/src/locales/ko.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '한쪽당 {0}회',
   'You still log the total: {0} is {1} per side.': '기록은 그대로 합계로 합니다: {0}회는 한쪽당 {1}회입니다.',
   '{0} sets · {1} work': '{0} 세트 · {1} 작업',
+  'Today’s sessions': '오늘의 세션',
+  'Choose a session': '세션 선택',
+  'Every planned session is done today — pick another routine or go freestyle.': '오늘 계획된 세션이 모두 완료되었습니다 — 다른 루틴을 고르거나 자유 운동하세요.'
 }

--- a/frontend/src/locales/pl.js
+++ b/frontend/src/locales/pl.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} na stronę',
   'You still log the total: {0} is {1} per side.': 'Nadal zapisujesz łączną liczbę: {0} to {1} na stronę.',
   '{0} sets · {1} work': '{0} serii · {1} praca',
+  'Today’s sessions': 'Dzisiejsze sesje',
+  'Choose a session': 'Wybierz sesję',
+  'Every planned session is done today — pick another routine or go freestyle.': 'Wszystkie dzisiejsze sesje ukończone — wybierz inną rutynę lub trenuj swobodnie.'
 }

--- a/frontend/src/locales/pt.js
+++ b/frontend/src/locales/pt.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} por lado',
   'You still log the total: {0} is {1} per side.': 'Continuas a registar o total: {0} são {1} por lado.',
   '{0} sets · {1} work': '{0} séries · {1} trabalho',
+  'Today’s sessions': 'Sessões de hoje',
+  'Choose a session': 'Escolher uma sessão',
+  'Every planned session is done today — pick another routine or go freestyle.': 'Todas as sessões de hoje estão feitas — escolha outra rotina ou treine livre.'
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '{0} на сторону',
   'You still log the total: {0} is {1} per side.': 'Ты по-прежнему записываешь общее число: {0} — это {1} на сторону.',
   '{0} sets · {1} work': '{0} подходов · {1} рабочих',
+  'Today’s sessions': 'Сегодняшние тренировки',
+  'Choose a session': 'Выбрать тренировку',
+  'Every planned session is done today — pick another routine or go freestyle.': 'Все запланированные тренировки на сегодня выполнены — выберите другую или тренируйтесь свободно.'
 }

--- a/frontend/src/locales/tr.js
+++ b/frontend/src/locales/tr.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': 'Taraf başına {0}',
   'You still log the total: {0} is {1} per side.': 'Toplamı kaydetmeye devam ediyorsun: {0}, taraf başına {1} demek.',
   '{0} sets · {1} work': '{0} set · {1} çalışma',
+  'Today’s sessions': 'Bugünkü seanslar',
+  'Choose a session': 'Bir seans seç',
+  'Every planned session is done today — pick another routine or go freestyle.': 'Bugünkü tüm planlı seanslar tamamlandı — başka bir rutin seç veya serbest çalış.'
 }

--- a/frontend/src/locales/zh.js
+++ b/frontend/src/locales/zh.js
@@ -567,4 +567,7 @@ export default {
   '{0} per side': '每侧 {0} 次',
   'You still log the total: {0} is {1} per side.': '你记录的仍然是总数：{0} 表示每侧 {1} 次。',
   '{0} sets · {1} work': '{0} 组 · {1} 工作',
+  'Today’s sessions': '今天的训练',
+  'Choose a session': '选择训练',
+  'Every planned session is done today — pick another routine or go freestyle.': '今天计划的训练均已完成 — 选择其他计划或自由训练。'
 }

--- a/frontend/src/sheets.jsx
+++ b/frontend/src/sheets.jsx
@@ -3,7 +3,7 @@ import { useStore } from './store/useStore.js'
 import { useUI } from './store/useUI.js'
 import { EXDB, EXIDX, BODYPARTS, isCardio, isBodyweightEq, allExercises, equipmentOf } from './lib/exercises.js'
 import { fmtDate, fmtNum, fmtVol, fmtDur, durPart, todayISO, uid, exCount, DAYN, MONTHS_LONG, ACCENTS } from './lib/format.js'
-import { lastEntryFor, bestWeightFor, buildSets, effectiveRoutineId, effectiveRoutineIds, workoutVolume, setsDone, setsDoneActive, lastBW, supersetUnits, unitOf, setLabel, defaultConfig, cleanupSg, modeOf, effortOf, isBw, isPerSide, sideReps, workSetsDone } from './lib/history.js'
+import { lastEntryFor, bestWeightFor, buildSets, effectiveRoutineId, effectiveRoutineIds, effectiveRoutines, workoutVolume, setsDone, setsDoneActive, lastBW, supersetUnits, unitOf, setLabel, defaultConfig, cleanupSg, modeOf, effortOf, isBw, isPerSide, sideReps, workSetsDone } from './lib/history.js'
 import { beep, vibrate } from './lib/sound.js'
 import { t, instrFor, getLang, INSTR_LANGS } from './lib/i18n.js'
 import { nav } from './lib/nav.js'
@@ -724,11 +724,15 @@ function DayOverride({ iso, close }) {
   return <>
     <h3>{fmtDate(iso, true)}</h3>
     <div className="muted small" style={{ marginBottom: 12 }}>{t('Weekly plan:')} {weeklyR ? weeklyR.name : t('Rest')}{hasOvr && <span style={{ color: 'var(--orange)' }}> · {t('changed for this day')}</span>}<br />{t('Pick one or more routines for this date. Tap a selected routine to remove it.')}</div>
+    <Button size="sm" variant="tinted" icon="calendar" style={{ marginBottom: 10 }} onClick={() => dayAssignSheet(wd)}>{t('Change the weekly plan for {0}', t(DAYN[wd]))}</Button>
     <div className="list">
       {st.routines.map(r => <div key={r.id} className="item" onClick={() => toggle(r.id)}>
         <span className="lrow-i"><Icon name={glyphOf(r.emoji)} /></span>
         <div className="grow"><div className="tt">{r.name}</div><div className="ss">{exCount(r.ex.length)}</div></div>
-        {selected.includes(r.id) && <Icon name="check" className="accent" />}</div>)}
+        {selected.includes(r.id) && <span className="row" style={{ gap: 6 }}>
+          <span style={{ background: 'var(--acc)', color: '#fff', borderRadius: 99, minWidth: 20, height: 20, padding: '0 5px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700 }}>{selected.indexOf(r.id) + 1}</span>
+          <Icon name="check" className="accent" />
+        </span>}</div>)}
       <div className="item" onClick={() => setSelected([])}><span className="lrow-i" style={{ background: 'var(--surface-3)' }}><Icon name="moon" /></span><div className="grow"><div className="tt">{t('Rest / skip this day')}</div></div>{!selected.length && <Icon name="check" className="accent" />}</div>
       {hasOvr && <div className="item" onClick={backToWeekly}><span className="lrow-i" style={{ background: 'var(--surface-3)' }}><Icon name="reset" /></span><div className="grow"><div className="tt">{t('Back to weekly plan')}</div></div></div>}
     </div>
@@ -831,6 +835,53 @@ export function WorkoutRow({ w, onClick }) {
 }
 
 /* ============================ workout lifecycle ============================ */
+// Session picker for days with multiple planned sessions (owner flow: small planner-style
+// buttons side by side, first uncompleted auto-selected, completed sessions ticked + greyed).
+// A sheet on purpose: swipe down to dismiss.
+function StartSessions({ close }) {
+  const S = useStore(s => s.S)
+  const todayPlans = effectiveRoutines(S, todayISO())
+  const iso = todayISO()
+  const doneToday = new Set()
+  ;(S.workouts || []).forEach(w => { if (String(w.d || '').slice(0, 10) === iso && w.routineId) doneToday.add(w.routineId) })
+  const [chosen, setChosen] = useState(() => {
+    const firstOpen = todayPlans.find(r => !doneToday.has(r.id))
+    return firstOpen ? firstOpen.id : (todayPlans.length ? todayPlans[0].id : null)
+  })
+  const selected = todayPlans.find(r => r.id === chosen) || null
+  const others = S.routines.filter(r => !todayPlans.some(p => p.id === r.id))
+  const go = id => { close(); startFlow(id) }
+  return <>
+    <h3>{t('Start workout')}</h3>
+    <div className="row" style={{ gap: 6, flexWrap: 'wrap', marginBottom: 12 }}>
+      {todayPlans.map(r => {
+        const done = doneToday.has(r.id)
+        const on = !done && r.id === chosen
+        return <button key={r.id} disabled={done} onClick={() => setChosen(r.id)}
+          className={'tag' + (on ? ' acc' : '')}
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 5, cursor: 'pointer', opacity: done ? .5 : 1, padding: '7px 11px' }}>
+          <Icon name={glyphOf(r.emoji)} /> {r.name} {done && <Icon name="check" className="accent" />}
+        </button>
+      })}
+    </div>
+    {selected
+      ? <Button variant="primary" icon="play" style={{ width: '100%' }} onClick={() => go(selected.id)}>{t('Start {0}', selected.name)}</Button>
+      : <div className="muted small" style={{ marginBottom: 10 }}>{t('Every planned session is done today \u2014 pick another routine or go freestyle.')}</div>}
+    {others.length > 0 && <>
+      <h4 className="sec">{t('Other routines')}</h4>
+      <div className="row" style={{ gap: 6, flexWrap: 'wrap', marginBottom: 12 }}>
+        {others.map(r => <button key={r.id} onClick={() => go(r.id)}
+          className="tag" style={{ display: 'inline-flex', alignItems: 'center', gap: 5, cursor: 'pointer', padding: '7px 11px' }}>
+          <Icon name={glyphOf(r.emoji)} /> {r.name}
+        </button>)}
+      </div>
+    </>}
+    <div style={{ height: 10 }} />
+    <Button icon="shuffle" style={{ width: '100%' }} onClick={() => go(null)}>{t('Freestyle workout (pick as you go)')}</Button>
+  </>
+}
+export const startSessionSheet = () => ui().openSheet(close => <StartSessions close={close} />)
+
 export function startFlow(routineId) {
   bwSheet({ required: true, onDone: bw => beginWorkout(routineId, bw) })
 }

--- a/frontend/src/sheets.jsx
+++ b/frontend/src/sheets.jsx
@@ -3,7 +3,7 @@ import { useStore } from './store/useStore.js'
 import { useUI } from './store/useUI.js'
 import { EXDB, EXIDX, BODYPARTS, isCardio, isBodyweightEq, allExercises, equipmentOf } from './lib/exercises.js'
 import { fmtDate, fmtNum, fmtVol, fmtDur, durPart, todayISO, uid, exCount, DAYN, MONTHS_LONG, ACCENTS } from './lib/format.js'
-import { lastEntryFor, bestWeightFor, buildSets, effectiveRoutineId, workoutVolume, setsDone, setsDoneActive, lastBW, supersetUnits, unitOf, setLabel, defaultConfig, cleanupSg, modeOf, effortOf, isBw, isPerSide, sideReps, workSetsDone } from './lib/history.js'
+import { lastEntryFor, bestWeightFor, buildSets, effectiveRoutineId, effectiveRoutineIds, workoutVolume, setsDone, setsDoneActive, lastBW, supersetUnits, unitOf, setLabel, defaultConfig, cleanupSg, modeOf, effortOf, isBw, isPerSide, sideReps, workSetsDone } from './lib/history.js'
 import { beep, vibrate } from './lib/sound.js'
 import { t, instrFor, getLang, INSTR_LANGS } from './lib/i18n.js'
 import { nav } from './lib/nav.js'
@@ -707,24 +707,35 @@ function DayOverride({ iso, close }) {
   const st = useStore(s => s.S)
   const wd = new Date(iso + 'T12:00:00').getDay()
   const weeklyR = st.routines.find(r => r.id === st.week[wd])
-  const hasOvr = st.dayPlan[iso] !== undefined
-  const effId = effectiveRoutineId(st, iso)
-  const set = v => {
-    update(s => { if (!v) delete s.dayPlan[iso]; else s.dayPlan[iso] = v })
+  const hasOvr = Object.prototype.hasOwnProperty.call(st.dayPlan || {}, iso)
+  const [selected, setSelected] = useState(() => effectiveRoutineIds(st, iso))
+  const toggle = id => setSelected(ids => ids.includes(id) ? ids.filter(x => x !== id) : [...ids, id])
+  const save = () => {
+    update(s => { s.dayPlan[iso] = selected.length ? selected.slice() : ['rest'] })
     close()
-    toast(v === '' ? t('Back to weekly plan') : v === 'rest' ? t('{0} set to rest', fmtDate(iso)) : t('{0} planned for {1}', (st.routines.find(r => r.id === v) || {}).name, fmtDate(iso)))
+    const names = selected.map(id => (st.routines.find(r => r.id === id) || {}).name).filter(Boolean)
+    toast(selected.length ? t('{0} planned for {1}', names.join(', '), fmtDate(iso)) : t('{0} set to rest', fmtDate(iso)))
+  }
+  const backToWeekly = () => {
+    update(s => { delete s.dayPlan[iso] })
+    close()
+    toast(t('Back to weekly plan'))
   }
   return <>
     <h3>{fmtDate(iso, true)}</h3>
-    <div className="muted small" style={{ marginBottom: 12 }}>{t('Weekly plan:')} {weeklyR ? weeklyR.name : t('Rest')}{hasOvr && <span style={{ color: 'var(--orange)' }}> · {t('changed for this day')}</span>}<br />{t('Sick, missed a day or want a different session? Pick what to train instead.')}</div>
+    <div className="muted small" style={{ marginBottom: 12 }}>{t('Weekly plan:')} {weeklyR ? weeklyR.name : t('Rest')}{hasOvr && <span style={{ color: 'var(--orange)' }}> · {t('changed for this day')}</span>}<br />{t('Pick one or more routines for this date. Tap a selected routine to remove it.')}</div>
     <div className="list">
-      {st.routines.map(r => <div key={r.id} className="item" onClick={() => set(r.id)}>
+      {st.routines.map(r => <div key={r.id} className="item" onClick={() => toggle(r.id)}>
         <span className="lrow-i"><Icon name={glyphOf(r.emoji)} /></span>
         <div className="grow"><div className="tt">{r.name}</div><div className="ss">{exCount(r.ex.length)}</div></div>
-        {effId === r.id && <Icon name="check" className="accent" />}</div>)}
-      <div className="item" onClick={() => set('rest')}><span className="lrow-i" style={{ background: 'var(--surface-3)' }}><Icon name="moon" /></span><div className="grow"><div className="tt">{t('Rest / skip this day')}</div></div>{effId === null && <Icon name="check" className="accent" />}</div>
-      {hasOvr && <div className="item" onClick={() => set('')}><span className="lrow-i" style={{ background: 'var(--surface-3)' }}><Icon name="reset" /></span><div className="grow"><div className="tt">{t('Back to weekly plan')}</div></div></div>}
+        {selected.includes(r.id) && <Icon name="check" className="accent" />}</div>)}
+      <div className="item" onClick={() => setSelected([])}><span className="lrow-i" style={{ background: 'var(--surface-3)' }}><Icon name="moon" /></span><div className="grow"><div className="tt">{t('Rest / skip this day')}</div></div>{!selected.length && <Icon name="check" className="accent" />}</div>
+      {hasOvr && <div className="item" onClick={backToWeekly}><span className="lrow-i" style={{ background: 'var(--surface-3)' }}><Icon name="reset" /></span><div className="grow"><div className="tt">{t('Back to weekly plan')}</div></div></div>}
     </div>
+    <div style={{ height: 10 }} />
+    <Button variant="primary" onClick={save}>{t('Save day plans')}</Button>
+    <div style={{ height: 8 }} />
+    <Button variant="ghost" className="dim" onClick={close}>{t('Cancel')}</Button>
   </>
 }
 export const dayOverrideSheet = iso => ui().openSheet(close => <DayOverride iso={iso} close={close} />)

--- a/frontend/src/sheets.jsx
+++ b/frontend/src/sheets.jsx
@@ -3,7 +3,7 @@ import { useStore } from './store/useStore.js'
 import { useUI } from './store/useUI.js'
 import { EXDB, EXIDX, BODYPARTS, isCardio, isBodyweightEq, allExercises, equipmentOf } from './lib/exercises.js'
 import { fmtDate, fmtNum, fmtVol, fmtDur, durPart, todayISO, uid, exCount, DAYN, MONTHS_LONG, ACCENTS } from './lib/format.js'
-import { lastEntryFor, bestWeightFor, buildSets, effectiveRoutineId, effectiveRoutineIds, effectiveRoutines, workoutVolume, setsDone, setsDoneActive, lastBW, supersetUnits, unitOf, setLabel, defaultConfig, cleanupSg, modeOf, effortOf, isBw, isPerSide, sideReps, workSetsDone } from './lib/history.js'
+import { lastEntryFor, bestWeightFor, buildSets, effectiveRoutineId, effectiveRoutineIds, effectiveRoutines, completedRoutineIdsForDate, reconcileStartSessionChoice, workoutVolume, setsDone, setsDoneActive, lastBW, supersetUnits, unitOf, setLabel, defaultConfig, cleanupSg, modeOf, effortOf, isBw, isPerSide, sideReps, workSetsDone, isWorkRow } from './lib/history.js'
 import { beep, vibrate } from './lib/sound.js'
 import { t, instrFor, getLang, INSTR_LANGS } from './lib/i18n.js'
 import { nav } from './lib/nav.js'
@@ -724,7 +724,7 @@ function DayOverride({ iso, close }) {
   return <>
     <h3>{fmtDate(iso, true)}</h3>
     <div className="muted small" style={{ marginBottom: 12 }}>{t('Weekly plan:')} {weeklyR ? weeklyR.name : t('Rest')}{hasOvr && <span style={{ color: 'var(--orange)' }}> · {t('changed for this day')}</span>}<br />{t('Pick one or more routines for this date. Tap a selected routine to remove it.')}</div>
-    <Button size="sm" variant="tinted" icon="calendar" style={{ marginBottom: 10 }} onClick={() => dayAssignSheet(wd)}>{t('Change the weekly plan for {0}', t(DAYN[wd]))}</Button>
+    <Button size="sm" variant="tinted" icon="calendar" style={{ marginBottom: 10 }} onClick={() => { close(); dayAssignSheet(wd) }}>{t('Change the weekly plan for {0}', t(DAYN[wd]))}</Button>
     <div className="list">
       {st.routines.map(r => <div key={r.id} className="item" onClick={() => toggle(r.id)}>
         <span className="lrow-i"><Icon name={glyphOf(r.emoji)} /></span>
@@ -838,17 +838,20 @@ export function WorkoutRow({ w, onClick }) {
 // Session picker for days with multiple planned sessions (owner flow: small planner-style
 // buttons side by side, first uncompleted auto-selected, completed sessions ticked + greyed).
 // A sheet on purpose: swipe down to dismiss.
-function StartSessions({ close }) {
+export { reconcileStartSessionChoice }
+
+export function StartSessions({ close }) {
   const S = useStore(s => s.S)
   const todayPlans = effectiveRoutines(S, todayISO())
   const iso = todayISO()
-  const doneToday = new Set()
-  ;(S.workouts || []).forEach(w => { if (String(w.d || '').slice(0, 10) === iso && w.routineId) doneToday.add(w.routineId) })
-  const [chosen, setChosen] = useState(() => {
-    const firstOpen = todayPlans.find(r => !doneToday.has(r.id))
-    return firstOpen ? firstOpen.id : (todayPlans.length ? todayPlans[0].id : null)
-  })
-  const selected = todayPlans.find(r => r.id === chosen) || null
+  const doneToday = completedRoutineIdsForDate(S, iso)
+  const planKey = todayPlans.map(r => r.id).join('\u0000')
+  const doneKey = [...doneToday].sort().join('\u0000')
+  const [chosen, setChosen] = useState(() => reconcileStartSessionChoice(todayPlans, doneToday, null))
+  useEffect(() => {
+    setChosen(current => reconcileStartSessionChoice(todayPlans, doneToday, current))
+  }, [planKey, doneKey])
+  const selected = todayPlans.find(r => r.id === chosen && !doneToday.has(r.id)) || null
   const others = S.routines.filter(r => !todayPlans.some(p => p.id === r.id))
   const go = id => { close(); startFlow(id) }
   return <>
@@ -866,7 +869,7 @@ function StartSessions({ close }) {
     </div>
     {selected
       ? <Button variant="primary" icon="play" style={{ width: '100%' }} onClick={() => go(selected.id)}>{t('Start {0}', selected.name)}</Button>
-      : <div className="muted small" style={{ marginBottom: 10 }}>{t('Every planned session is done today \u2014 pick another routine or go freestyle.')}</div>}
+      : <div className="muted small" style={{ marginBottom: 10 }}>{t('Every planned session is done today — pick another routine or go freestyle.')}</div>}
     {others.length > 0 && <>
       <h4 className="sec">{t('Other routines')}</h4>
       <div className="row" style={{ gap: 6, flexWrap: 'wrap', marginBottom: 12 }}>
@@ -911,7 +914,7 @@ function TopWeight({ entryIdx, close }) {
   // to sit after every one of them.
   const entry = A ? A.entries[entryIdx] : null
   const ex = entry && EXIDX[entry.id]
-  const maxSet = entry ? Math.max(0, ...entry.sets.filter(s => s.done).map(s => s.w || 0)) : 0
+  const maxSet = entry ? Math.max(0, ...entry.sets.filter(s => s.done && isWorkRow(s)).map(s => s.w || 0)) : 0
   const prevBest = entry ? Math.max((st.exWeights[entry.id] || {}).w || 0, bestWeightFor(st, entry.id)) : 0
   const [v, setV] = useState(entry ? (Math.max(maxSet, prevBest) || entry.target.weight || 0) : 0)
   useEffect(() => { if (!entry) close() }, [!entry])
@@ -1001,7 +1004,7 @@ function doFinishWorkout() {
   const prs = []
   const e1prs = []
   A.entries.forEach(e => {
-    const mx = Math.max(0, ...e.sets.filter(s => s.done).map(s => s.w))
+    const mx = Math.max(0, ...e.sets.filter(s => s.done && isWorkRow(s)).map(s => s.w))
     if (mx > 0 && mx > bestWeightFor(st, e.id)) prs.push(e.id)
     // A heavier estimate without a heavier top set is its own kind of progress —
     // same weight for more reps. Reported separately so it can't be read as a load PR.
@@ -1019,7 +1022,7 @@ function doFinishWorkout() {
   w.vol = workoutVolume(w)
   update(s => {
     w.entries.forEach(e => {
-      const mx = Math.max(0, ...e.sets.filter(x => x.done).map(x => x.w || 0), e.topW || 0)
+      const mx = Math.max(0, ...e.sets.filter(x => x.done && isWorkRow(x)).map(x => x.w || 0), e.topW || 0)
       if (mx > 0) { const cur = s.exWeights[e.id]; if (!cur || mx > cur.w) s.exWeights[e.id] = { w: mx, d: w.d } }
     })
     s.workouts.push(w)

--- a/frontend/src/store/useStore.js
+++ b/frontend/src/store/useStore.js
@@ -5,6 +5,7 @@ import { registerCustom } from '../lib/exercises.js'
 import { DEMO, DEMO_SEEDED } from '../lib/demo.js'
 import { guestAllowed } from '../lib/guest.js'
 import { MOBILE, nativeLoad, nativeSave, syncReminder } from '../lib/mobile.js'
+import { normalizeDayPlan } from '../lib/history.js'
 
 const KEY = 'gym_state_v1'
 export const DEF = {
@@ -23,7 +24,7 @@ const clone = o => JSON.parse(JSON.stringify(o))
 function loadState() {
   try {
     const raw = localStorage.getItem(KEY)
-    if (raw) return Object.assign(clone(DEF), JSON.parse(raw))
+    if (raw) return normalizeDayPlan(Object.assign(clone(DEF), JSON.parse(raw)))
   } catch (e) { /* ignore */ }
   return clone(DEF)
 }
@@ -42,10 +43,11 @@ export const useStore = create((set, get) => {
   }
 
   const persist = (S, push = true) => {
-    S._ts = Date.now()
-    registerCustom(S.customEx)
-    localStorage.setItem(KEY, JSON.stringify(S))
-    set({ S })
+    const next = normalizeDayPlan(S)
+    next._ts = Date.now()
+    registerCustom(next.customEx)
+    localStorage.setItem(KEY, JSON.stringify(next))
+    set({ S: next })
     if (MOBILE) nativePersist()
     if (push && get().user) {
       clearTimeout(pushTm)
@@ -91,7 +93,7 @@ export const useStore = create((set, get) => {
       mut(S)
       persist(S, push)
     },
-    replaceState(S, push = false) { persist(clone(S), push) },
+    replaceState(S, push = false) { persist(normalizeDayPlan(clone(S)), push) },
 
     isGuest: () => localStorage.getItem('gym_guest') === '1',
     setGuest(v) { if (v) localStorage.setItem('gym_guest', '1'); else localStorage.removeItem('gym_guest'); set({}) },
@@ -125,7 +127,7 @@ export const useStore = create((set, get) => {
         const dirty = localStorage.getItem('gym_dirty') === '1'
         if (state && (!hasData(S) || ((state._ts || 0) >= (S._ts || 0) && !dirty))) {
           const active = S.active
-          const next = Object.assign(clone(DEF), state)
+          const next = normalizeDayPlan(Object.assign(clone(DEF), state))
           if (active) next.active = active
           persist(next, false)
         } else if (hasData(S)) { await get().pushState() }
@@ -164,7 +166,7 @@ export const useStore = create((set, get) => {
         const saved = await nativeLoad()
         const S = get().S
         if (saved && (!hasData(S) || (saved._ts || 0) >= (S._ts || 0))) {
-          persist(Object.assign(clone(DEF), saved), false)
+          persist(normalizeDayPlan(Object.assign(clone(DEF), saved)), false)
         } else if (hasData(S)) {
           nativeSave(S)   // first run after an update from a file-less version: seed the mirror
         }

--- a/frontend/src/views/Home.jsx
+++ b/frontend/src/views/Home.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
-import { effectiveRoutine, effectiveRoutineId, streakWeeks, lastBW, setsDoneActive } from '../lib/history.js'
+import { effectiveRoutines, effectiveRoutineIds, streakWeeks, lastBW, setsDoneActive } from '../lib/history.js'
 import { fmtNum, fmtDate, todayISO, isoOf, weekKey, DAYS } from '../lib/format.js'
 import { t, dateLocale } from '../lib/i18n.js'
 import { bwSheet, goalSheet, dayOverrideSheet, calendarSheet, startFlow, loadStarterPlan, bwDeltaColor } from '../sheets.jsx'
@@ -18,8 +18,9 @@ export default function Home() {
   const [weekOffset, setWeekOffset] = useState(0)
 
   const today = new Date()
-  const routine = effectiveRoutine(S, todayISO())
-  const todayOvr = S.dayPlan[todayISO()] !== undefined
+  const todayPlans = effectiveRoutines(S, todayISO())
+  const routine = todayPlans[0]
+  const todayOvr = Object.prototype.hasOwnProperty.call(S.dayPlan || {}, todayISO())
   const bw = lastBW(S)
   const prevBW = S.bodyweight.length > 1 ? S.bodyweight[S.bodyweight.length - 2] : null
   const delta = bw && prevBW ? bw.w - prevBW.w : null
@@ -30,8 +31,8 @@ export default function Home() {
   for (let i = 0; i < 7; i++) {
     const d = new Date(monday); d.setDate(monday.getDate() + i)
     const iso = isoOf(d)
-    const eff = effectiveRoutineId(S, iso), ovr = S.dayPlan[iso] !== undefined, done = doneDays.has(iso)
-    const dot = done ? ' done' : ovr && eff ? ' ovr' : eff ? ' plan' : ''
+    const eff = effectiveRoutineIds(S, iso), ovr = Object.prototype.hasOwnProperty.call(S.dayPlan || {}, iso), done = doneDays.has(iso)
+    const dot = done ? ' done' : ovr && eff.length ? ' ovr' : eff.length ? ' plan' : ''
     strip.push(<div key={i} className={'wday' + (iso === todayISO() ? ' today' : '')} onClick={() => dayOverrideSheet(iso)}>
       <div className="lbl">{t(DAYS[d.getDay()])}</div><div className="num">{d.getDate()}</div><div className={'dot' + dot} /></div>)
   }
@@ -43,7 +44,7 @@ export default function Home() {
   const bwPoints = S.bodyweight.slice(-30).map(b => ({ t: b.t || new Date(b.d).getTime(), y: b.w, d: b.d }))
 
   // today's session shown right under the week strip
-  const onToday = () => { if (S.active) nav('/workout'); else if (routine) startFlow(routine.id); else dayOverrideSheet(todayISO()) }
+  const onToday = () => { if (S.active) nav('/workout'); else if (todayPlans.length === 1) startFlow(routine.id); else if (todayPlans.length > 1) nav('/workout'); else dayOverrideSheet(todayISO()) }
 
   return <div className="narrow">
     <div className="hdr">
@@ -65,7 +66,7 @@ export default function Home() {
           </span>
           <div style={{ minWidth: 0 }}>
             <div className="lbl2">{t('Today')}</div>
-            <div className="ttl">{S.active ? t('{0} — in progress', S.active.name) : routine ? routine.name : t('Rest day')}{todayOvr && routine ? ' · ' + t('rescheduled') : ''}</div>
+            <div className="ttl">{S.active ? t('{0} — in progress', S.active.name) : todayPlans.length ? todayPlans.map(r => r.name).join(' + ') : t('Rest day')}{todayOvr && todayPlans.length ? ' · ' + t('rescheduled') : ''}</div>
           </div>
         </div>
         {S.active ? <span className="tag" style={{ color: 'var(--orange)', background: 'color-mix(in srgb,var(--orange) 16%,transparent)' }}>{t('Resume')}</span>

--- a/frontend/src/views/Home.jsx
+++ b/frontend/src/views/Home.jsx
@@ -4,7 +4,7 @@ import { useStore } from '../store/useStore.js'
 import { effectiveRoutines, effectiveRoutineIds, streakWeeks, lastBW, setsDoneActive } from '../lib/history.js'
 import { fmtNum, fmtDate, todayISO, isoOf, weekKey, DAYS } from '../lib/format.js'
 import { t, dateLocale } from '../lib/i18n.js'
-import { bwSheet, goalSheet, dayOverrideSheet, calendarSheet, startFlow, loadStarterPlan, bwDeltaColor } from '../sheets.jsx'
+import { bwSheet, goalSheet, dayOverrideSheet, calendarSheet, startFlow, startSessionSheet, loadStarterPlan, bwDeltaColor } from '../sheets.jsx'
 import LineChart from '../components/LineChart.jsx'
 import Icon from '../components/Icon.jsx'
 import { Button } from '../components/ui.jsx'
@@ -44,7 +44,7 @@ export default function Home() {
   const bwPoints = S.bodyweight.slice(-30).map(b => ({ t: b.t || new Date(b.d).getTime(), y: b.w, d: b.d }))
 
   // today's session shown right under the week strip
-  const onToday = () => { if (S.active) nav('/workout'); else if (todayPlans.length === 1) startFlow(routine.id); else if (todayPlans.length > 1) nav('/workout'); else dayOverrideSheet(todayISO()) }
+  const onToday = () => { if (S.active) nav('/workout'); else if (todayPlans.length === 1) startFlow(routine.id); else if (todayPlans.length > 1) startSessionSheet(); else dayOverrideSheet(todayISO()) }
 
   return <div className="narrow">
     <div className="hdr">

--- a/frontend/src/views/Home.jsx
+++ b/frontend/src/views/Home.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
-import { effectiveRoutines, effectiveRoutineIds, streakWeeks, lastBW, setsDoneActive } from '../lib/history.js'
+import { effectiveRoutines, effectiveRoutineIds, completedRoutineIdsForDate, reconcileStartSessionChoice, streakWeeks, lastBW, setsDoneActive } from '../lib/history.js'
 import { fmtNum, fmtDate, todayISO, isoOf, weekKey, DAYS } from '../lib/format.js'
 import { t, dateLocale } from '../lib/i18n.js'
 import { bwSheet, goalSheet, dayOverrideSheet, calendarSheet, startFlow, startSessionSheet, loadStarterPlan, bwDeltaColor } from '../sheets.jsx'
@@ -20,6 +20,9 @@ export default function Home() {
   const today = new Date()
   const todayPlans = effectiveRoutines(S, todayISO())
   const routine = todayPlans[0]
+  const doneToday = completedRoutineIdsForDate(S, todayISO())
+  const openRoutineId = reconcileStartSessionChoice(todayPlans, doneToday, null)
+  const openRoutine = todayPlans.find(r => r.id === openRoutineId) || null
   const todayOvr = Object.prototype.hasOwnProperty.call(S.dayPlan || {}, todayISO())
   const bw = lastBW(S)
   const prevBW = S.bodyweight.length > 1 ? S.bodyweight[S.bodyweight.length - 2] : null
@@ -44,7 +47,12 @@ export default function Home() {
   const bwPoints = S.bodyweight.slice(-30).map(b => ({ t: b.t || new Date(b.d).getTime(), y: b.w, d: b.d }))
 
   // today's session shown right under the week strip
-  const onToday = () => { if (S.active) nav('/workout'); else if (todayPlans.length === 1) startFlow(routine.id); else if (todayPlans.length > 1) startSessionSheet(); else dayOverrideSheet(todayISO()) }
+  const onToday = () => {
+    if (S.active) nav('/workout')
+    else if (todayPlans.length === 1 && openRoutine) startFlow(openRoutine.id)
+    else if (todayPlans.length) startSessionSheet()
+    else dayOverrideSheet(todayISO())
+  }
 
   return <div className="narrow">
     <div className="hdr">
@@ -70,7 +78,8 @@ export default function Home() {
           </div>
         </div>
         {S.active ? <span className="tag" style={{ color: 'var(--orange)', background: 'color-mix(in srgb,var(--orange) 16%,transparent)' }}>{t('Resume')}</span>
-          : routine ? <span className="tag acc">{t('Start')}</span>
+          : openRoutine ? <span className="tag acc">{t('Start')}</span>
+          : todayPlans.length ? <span className="tag">{t('Done')}</span>
           : <Icon name="plus" className="chev" />}
       </div>
     </div>

--- a/frontend/src/views/Plan.jsx
+++ b/frontend/src/views/Plan.jsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
-import { DAYN, uid, exCount, todayISO, fmtDate } from '../lib/format.js'
-import { effectiveRoutines } from '../lib/history.js'
+import { DAYN, uid, exCount, todayISO, fmtDate, isoOf } from '../lib/format.js'
+import { effectiveRoutines, effectiveRoutineIds } from '../lib/history.js'
 import { t } from '../lib/i18n.js'
 import { dayAssignSheet, dayOverrideSheet, loadStarterPlan, planToolsSheet } from '../sheets.jsx'
 import Icon from '../components/Icon.jsx'
@@ -10,6 +10,13 @@ import { Button } from '../components/ui.jsx'
 import { glyphOf, DEFAULT_GLYPH } from '../lib/glyphs.js'
 
 export default function Plan() {
+  // The next real date for a weekday - tapping a day opens the multi-plan picker for it.
+  const nextDateOf = d => {
+    const t = new Date(todayISO() + 'T12:00:00')
+    const diff = (d - t.getDay() + 7) % 7
+    t.setDate(t.getDate() + diff)
+    return isoOf(t)
+  }
   const nav = useNavigate()
   const S = useStore(s => s.S)
   const update = useStore(s => s.update)
@@ -32,9 +39,22 @@ export default function Plan() {
       <div className="list" style={{ display: 'flex', flexDirection: 'column' }}>
         {[1, 2, 3, 4, 5, 6, 0].map(d => {
           const r = S.routines.find(x => x.id === S.week[d])
-          return <div key={d} className="item" onClick={() => dayAssignSheet(d)}>
-            <div className="grow"><div className="tt">{t(DAYN[d])}</div></div>
-            {r ? <span className="tag acc"><Icon name={glyphOf(r.emoji)} />{r.name}</span> : <span className="tag">{t('Rest')}</span>}
+          const iso = nextDateOf(d)
+          const dayPlans = effectiveRoutineIds(S, iso)
+          const overridden = Object.prototype.hasOwnProperty.call(S.dayPlan || {}, iso)
+          const shown = overridden && dayPlans.length ? dayPlans : (r ? [r.id] : [])
+          return <div key={d} className="item" onClick={() => dayOverrideSheet(iso)}>
+            <div className="grow">
+              <div className="row" style={{ alignItems: 'flex-start', gap: 8, flexWrap: 'wrap' }}>
+                <div className="tt">{t(DAYN[d])}</div>
+                {shown.length ? <div className="row" style={{ gap: 4, flexWrap: 'wrap', justifyContent: 'flex-end', flex: '1 1 auto', minWidth: 0, maxHeight: 64, overflow: 'hidden' }}>
+                  {shown.map((pid, i) => {
+                    const pr = S.routines.find(x => x.id === pid)
+                    return pr ? <span key={pid} className="tag acc" style={{ marginRight: 0 }}><Icon name={glyphOf(pr.emoji)} />{overridden && <b style={{ marginRight: 3 }}>{i + 1}.</b>}{pr.name}</span> : null
+                  })}
+                </div> : <span className="tag">{t('Rest')}</span>}
+              </div>
+            </div>
             <Icon name="chevronRight" className="chev" /></div>
         })}
       </div>

--- a/frontend/src/views/Plan.jsx
+++ b/frontend/src/views/Plan.jsx
@@ -1,8 +1,10 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
-import { DAYN, uid, exCount } from '../lib/format.js'
+import { DAYN, uid, exCount, todayISO, fmtDate } from '../lib/format.js'
+import { effectiveRoutines } from '../lib/history.js'
 import { t } from '../lib/i18n.js'
-import { dayAssignSheet, loadStarterPlan, planToolsSheet } from '../sheets.jsx'
+import { dayAssignSheet, dayOverrideSheet, loadStarterPlan, planToolsSheet } from '../sheets.jsx'
 import Icon from '../components/Icon.jsx'
 import { Button } from '../components/ui.jsx'
 import { glyphOf, DEFAULT_GLYPH } from '../lib/glyphs.js'
@@ -11,6 +13,8 @@ export default function Plan() {
   const nav = useNavigate()
   const S = useStore(s => s.S)
   const update = useStore(s => s.update)
+  const [date, setDate] = useState(todayISO())
+  const overrides = Object.keys(S.dayPlan || {}).sort()
 
   const addRoutine = () => {
     const r = { id: uid(), name: t('New routine'), emoji: DEFAULT_GLYPH, ex: [] }
@@ -34,6 +38,19 @@ export default function Plan() {
             <Icon name="chevronRight" className="chev" /></div>
         })}
       </div>
+      <h4 className="sec" style={{ marginTop: 22 }}>{t('Date-specific plans')}</h4>
+      <div className="small dim" style={{ margin: '-4px 2px 10px', lineHeight: 1.4 }}>{t('Add or remove multiple routines for one date without changing the weekly schedule.')}</div>
+      <div className="row" style={{ gap: 8, marginBottom: 10 }}>
+        <input className="input" type="date" value={date} onChange={e => setDate(e.target.value)} aria-label={t('Date')} style={{ minWidth: 0, flex: 1 }} />
+        <Button size="sm" variant="tinted" icon="calendar" onClick={() => date && dayOverrideSheet(date)}>{t('Edit day')}</Button>
+      </div>
+      {overrides.length > 0 && <div className="list">{overrides.map(iso => {
+        const plans = effectiveRoutines(S, iso)
+        return <div key={iso} className="item" onClick={() => dayOverrideSheet(iso)}>
+          <div className="grow"><div className="tt">{fmtDate(iso, true)}</div><div className="ss">{plans.length ? plans.map(r => r.name).join(' + ') : t('Rest')}</div></div>
+          <Icon name="chevronRight" className="chev" />
+        </div>
+      })}</div>}
     </div><div>
       <div className="row between" style={{ marginTop: 22, marginBottom: 10 }}>
         <h4 className="sec" style={{ margin: 0 }}>{t('Routines')}</h4>

--- a/frontend/src/views/RoutineEdit.jsx
+++ b/frontend/src/views/RoutineEdit.jsx
@@ -102,7 +102,14 @@ export default function RoutineEdit() {
         update(s => {
           s.routines = s.routines.filter(x => x.id !== id)
           Object.keys(s.week).forEach(k => { if (s.week[k] === id) delete s.week[k] })
-          Object.keys(s.dayPlan).forEach(k => { if (s.dayPlan[k] === id) delete s.dayPlan[k] })
+          Object.keys(s.dayPlan).forEach(k => {
+            const value = s.dayPlan[k]
+            if (Array.isArray(value)) {
+              const kept = value.filter(x => x !== id)
+              if (kept.length) s.dayPlan[k] = kept
+              else delete s.dayPlan[k]
+            } else if (value === id) delete s.dayPlan[k]
+          })
         })
         nav('/plan')
       }

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -23,17 +23,29 @@ function StartChooser() {
   const todayOvr = Object.prototype.hasOwnProperty.call(S.dayPlan || {}, todayISO())
   const plannedIds = new Set(todayPlans.map(r => r.id))
   const others = S.routines.filter(r => !plannedIds.has(r.id))
-  const todayLabel = todayPlans.length ? todayPlans.map(r => r.name).join(', ') : t('rest day, but no one’s stopping you')
+  const iso = todayISO()
+  const doneToday = new Set()
+  ;(S.workouts || []).forEach(w => { if (String(w.d || '').slice(0, 10) === iso && w.routineId) doneToday.add(w.routineId) })
+  const todayLabel = todayPlans.length ? todayPlans.map(r => r.name).join(', ') : t('rest day, but no one\u2019s stopping you')
   return <div className="narrow">
-    <div className="hdr"><div><h1>{t('Start workout')}</h1><div className="sub">{t(DAYN[new Date().getDay()])} — {todayPlans.length ? t('today is {0}', todayLabel) : todayLabel}</div></div></div>
-    {todayPlans.map(todayR => <div key={todayR.id} className="card" style={{ borderColor: 'var(--acc)' }}>
-      <h2 className="accent">{t("Today's plan")}{todayOvr ? ' · ' + t('rescheduled') : ''}</h2>
-      <div className="row between" style={{ marginBottom: 12 }}>
-        <div><div className="big">{todayR.name}</div><div className="muted small">{exCount(todayR.ex.length)}</div></div>
-        <span className="lrow-i" style={{ width: 38, height: 38, borderRadius: 9, fontSize: 22 }}><Icon name={glyphOf(todayR.emoji)} /></span>
+    <div className="hdr"><div><h1>{t('Start workout')}</h1><div className="sub">{t(DAYN[new Date().getDay()])} \u2014 {todayPlans.length ? t('today is {0}', todayLabel) : todayLabel}</div></div></div>
+    {todayPlans.length === 1 && !doneToday.has(todayPlans[0].id) && (
+      <div className="card" style={{ borderColor: 'var(--acc)' }}>
+        <h2 className="accent">{t("Today's plan")}{todayOvr ? ' \u00b7 ' + t('rescheduled') : ''}</h2>
+        <div className="row between" style={{ marginBottom: 12 }}>
+          <div><div className="big">{todayPlans[0].name}</div><div className="muted small">{exCount(todayPlans[0].ex.length)}</div></div>
+          <span className="lrow-i" style={{ width: 38, height: 38, borderRadius: 9, fontSize: 22 }}><Icon name={glyphOf(todayPlans[0].emoji)} /></span>
+        </div>
+        <Button variant="primary" icon="play" onClick={() => startFlow(todayPlans[0].id)}>{t('Start {0}', todayPlans[0].name)}</Button>
       </div>
-      <Button variant="primary" icon="play" onClick={() => startFlow(todayR.id)}>{t('Start {0}', todayR.name)}</Button>
-    </div>)}
+    )}
+    {todayPlans.length > 1 && (
+      <div className="card">
+        <h2 className="accent">{t('Today’s sessions')}</h2>
+        <div className="muted small" style={{ marginBottom: 10 }}>{todayLabel}</div>
+        <Button variant="primary" icon="play" onClick={() => startSessionSheet()}>{t('Choose a session')}</Button>
+      </div>
+    )}
     {others.length > 0 && <><h4 className="sec">{t('Other routines')}</h4>
       <div className="list">{others.map(r => <div key={r.id} className="item" onClick={() => startFlow(r.id)}>
         <span className="lrow-i"><Icon name={glyphOf(r.emoji)} /></span>

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
 import { useUI } from '../store/useUI.js'
 import { exOr } from '../lib/exercises.js'
-import { effectiveRoutine, lastEntryFor, bestWeightFor, buildSets, freestyleConfig, defaultConfig, setsDoneActive, supersetUnits, unitOf, setLabel, modeOf, isBw, isPerSide, sideReps, repStep, EFFORT, effortOf, stepEffort, capEffort, cascadeWeight, insertWarmupRow, removeRowAt } from '../lib/history.js'
+import { effectiveRoutine, effectiveRoutines, lastEntryFor, bestWeightFor, buildSets, freestyleConfig, defaultConfig, setsDoneActive, supersetUnits, unitOf, setLabel, modeOf, isBw, isPerSide, sideReps, repStep, EFFORT, effortOf, stepEffort, capEffort, cascadeWeight, insertWarmupRow, removeRowAt } from '../lib/history.js'
 import { fmtNum, fmtDate, todayISO, exCount, DAYN } from '../lib/format.js'
 import { beep, vibrate } from '../lib/sound.js'
 import { t } from '../lib/i18n.js'
@@ -19,19 +19,21 @@ import { glyphOf } from '../lib/glyphs.js'
 function StartChooser() {
   const nav = useNavigate()
   const S = useStore(s => s.S)
-  const todayR = effectiveRoutine(S, todayISO())
-  const todayOvr = S.dayPlan[todayISO()] !== undefined
-  const others = S.routines.filter(r => r !== todayR)
+  const todayPlans = effectiveRoutines(S, todayISO())
+  const todayOvr = Object.prototype.hasOwnProperty.call(S.dayPlan || {}, todayISO())
+  const plannedIds = new Set(todayPlans.map(r => r.id))
+  const others = S.routines.filter(r => !plannedIds.has(r.id))
+  const todayLabel = todayPlans.length ? todayPlans.map(r => r.name).join(', ') : t('rest day, but no one’s stopping you')
   return <div className="narrow">
-    <div className="hdr"><div><h1>{t('Start workout')}</h1><div className="sub">{t(DAYN[new Date().getDay()])} — {todayR ? t('today is {0}', todayR.name) : t('rest day, but no one’s stopping you')}</div></div></div>
-    {todayR && <div className="card" style={{ borderColor: 'var(--acc)' }}>
+    <div className="hdr"><div><h1>{t('Start workout')}</h1><div className="sub">{t(DAYN[new Date().getDay()])} — {todayPlans.length ? t('today is {0}', todayLabel) : todayLabel}</div></div></div>
+    {todayPlans.map(todayR => <div key={todayR.id} className="card" style={{ borderColor: 'var(--acc)' }}>
       <h2 className="accent">{t("Today's plan")}{todayOvr ? ' · ' + t('rescheduled') : ''}</h2>
       <div className="row between" style={{ marginBottom: 12 }}>
         <div><div className="big">{todayR.name}</div><div className="muted small">{exCount(todayR.ex.length)}</div></div>
         <span className="lrow-i" style={{ width: 38, height: 38, borderRadius: 9, fontSize: 22 }}><Icon name={glyphOf(todayR.emoji)} /></span>
       </div>
       <Button variant="primary" icon="play" onClick={() => startFlow(todayR.id)}>{t('Start {0}', todayR.name)}</Button>
-    </div>}
+    </div>)}
     {others.length > 0 && <><h4 className="sec">{t('Other routines')}</h4>
       <div className="list">{others.map(r => <div key={r.id} className="item" onClick={() => startFlow(r.id)}>
         <span className="lrow-i"><Icon name={glyphOf(r.emoji)} /></span>

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
 import { useUI } from '../store/useUI.js'
 import { exOr } from '../lib/exercises.js'
-import { effectiveRoutine, effectiveRoutines, lastEntryFor, bestWeightFor, buildSets, freestyleConfig, defaultConfig, setsDoneActive, supersetUnits, unitOf, setLabel, modeOf, isBw, isPerSide, sideReps, repStep, EFFORT, effortOf, stepEffort, capEffort, cascadeWeight, insertWarmupRow, removeRowAt } from '../lib/history.js'
+import { effectiveRoutine, effectiveRoutines, completedRoutineIdsForDate, lastEntryFor, bestWeightFor, buildSets, freestyleConfig, defaultConfig, setsDoneActive, supersetUnits, unitOf, setLabel, modeOf, isBw, isPerSide, sideReps, repStep, EFFORT, effortOf, stepEffort, capEffort, cascadeWeight, insertWarmupRow, removeRowAt, isWarmupRow } from '../lib/history.js'
 import { fmtNum, fmtDate, todayISO, exCount, DAYN } from '../lib/format.js'
 import { beep, vibrate } from '../lib/sound.js'
 import { t } from '../lib/i18n.js'
@@ -23,10 +23,8 @@ function StartChooser() {
   const todayOvr = Object.prototype.hasOwnProperty.call(S.dayPlan || {}, todayISO())
   const plannedIds = new Set(todayPlans.map(r => r.id))
   const others = S.routines.filter(r => !plannedIds.has(r.id))
-  const iso = todayISO()
-  const doneToday = new Set()
-  ;(S.workouts || []).forEach(w => { if (String(w.d || '').slice(0, 10) === iso && w.routineId) doneToday.add(w.routineId) })
-  const todayLabel = todayPlans.length ? todayPlans.map(r => r.name).join(', ') : t('rest day, but no one\u2019s stopping you')
+  const doneToday = completedRoutineIdsForDate(S, todayISO())
+  const todayLabel = todayPlans.length ? todayPlans.map(r => r.name).join(', ') : t('rest day, but no one’s stopping you')
   return <div className="narrow">
     <div className="hdr"><div><h1>{t('Start workout')}</h1><div className="sub">{t(DAYN[new Date().getDay()])} \u2014 {todayPlans.length ? t('today is {0}', todayLabel) : todayLabel}</div></div></div>
     {todayPlans.length === 1 && !doneToday.has(todayPlans[0].id) && (
@@ -55,6 +53,12 @@ function StartChooser() {
     <Button icon="shuffle" onClick={() => startFlow(null)}>{t('Freestyle workout (pick as you go)')}</Button>
     {!S.routines.length && <><div style={{ height: 10 }} /><Button variant="primary" onClick={() => nav('/plan')}>{t('Build a plan first')}</Button></>}
   </div>
+}
+
+export function emptyWorkoutMessage(routineId) {
+  return routineId
+    ? `${t('{0} workout', t('Planned'))} — ${t('Add exercise')}`
+    : t('Freestyle workout — add your first exercise.')
 }
 
 /* ---------- elapsed clock (isolated so the workout tree doesn't re-render every second) ---------- */
@@ -146,13 +150,13 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
       {/* the header carries the same eff3 sizing as the rows, or the labels drift off their columns */}
       <div className={'sethead' + (col3 ? ' eff3' : '')}><span className="n-sp" /><span className="w-sp">{col1.hd}</span>{col2 && <span className="r-sp">{col2.hd}</span>}{col3 && <span className="eff-sp">{col3.hd}</span>}{timed && <span className="ck-sp" />}<span className="ck-sp" /></div>
       {entry.sets.map((s, i) => {
-        const warmBefore = i > 0 && !!entry.sets[i - 1].warmup
-        const isFirstWarmup = !!s.warmup && !warmBefore
+        const warmBefore = i > 0 && isWarmupRow(entry.sets[i - 1])
+        const isFirstWarmup = isWarmupRow(s) && !warmBefore
         // Numbering restarts per phase: with two warm-ups the first work set reads 1, not 3.
-        const phaseNum = entry.sets.slice(0, i + 1).filter(x => (x.warmup === true) === (s.warmup === true)).length
+        const phaseNum = entry.sets.slice(0, i + 1).filter(x => isWarmupRow(x) === isWarmupRow(s)).length
         return <div key={i}>
           {isFirstWarmup && <div className="setph">{t('Warm-up')}</div>}
-          {!s.warmup && warmBefore && <div className="setsep" />}
+          {!isWarmupRow(s) && warmBefore && <div className="setsep" />}
           <div className={'setrow' + (s.done ? ' done' : '') + (col3 ? ' eff3' : '')}>
             <div className="n">{phaseNum}</div>
             {cell(s, i, col1, 'w')}
@@ -162,7 +166,7 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
                 set off itself. The checkbox stays for anyone who timed it on their own watch. */}
             {timed && <button className="setgo" aria-label={t('Start set')} disabled={s.done || !!working}
               onClick={() => onStartTimed(i)}><Icon name="play" /></button>}
-            {s.warmup && <button className="iconbtn" style={{ fontSize: 13 }} aria-label={t('Remove set')}
+            {isWarmupRow(s) && <button className="iconbtn" style={{ fontSize: 13 }} aria-label={t('Remove set')}
               disabled={entry.sets.length <= 1} onClick={() => onRemoveSetAt(i)}><Icon name="xmark" /></button>}
             <Check checked={s.done} onChange={() => onToggle(i)} />
           </div>

--- a/mcp/src/tools.js
+++ b/mcp/src/tools.js
@@ -7,7 +7,7 @@ import {
   setLabel, exLine, muscleName, policyName, friendlyDuration, ratio, muscleOrder
 } from './labels.js'
 import {
-  modeOf, workoutVolume, setsDone, effectiveRoutine, effectiveRoutineId
+  modeOf, workoutVolume, setsDone, effectiveRoutineIds, effectiveRoutines
 } from '../../frontend/src/lib/history.js'
 import { EXIDX, exOr } from '../../frontend/src/lib/exercises.js'
 import {
@@ -134,7 +134,7 @@ export const getRoutine = {
 /** get_week_plan — what's scheduled each weekday + today. */
 export const getWeekPlan = {
   name: 'get_week_plan',
-  description: 'Show the user\'s weekly plan: which routine (if any) is assigned to each weekday, keyed by JS getDay() (Sunday=0, Monday=1, … Saturday=6 — the same convention the openGym state file uses). Also reports today\'s date and what routine applies today, accounting for one-off overrides the user may have set for a specific date (a "rest" override cancels the day).',
+  description: 'Show the user\'s weekly plan: which routine (if any) is assigned to each weekday, keyed by JS getDay() (Sunday=0, Monday=1, … Saturday=6 — the same convention the openGym state file uses). Also reports today\'s date and every routine that applies today, accounting for one-off overrides the user may have set for a specific date (a "rest" override cancels the day). Singular today_routine_id/name fields remain as the first routine for compatibility.',
   schema: {},
   handler: () => {
     const S = getState()
@@ -142,6 +142,8 @@ export const getWeekPlan = {
     const today = new Date()
     const isoToday = today.getFullYear() + '-' + String(today.getMonth() + 1).padStart(2, '0') + '-' + String(today.getDate()).padStart(2, '0')
     const todayWd = today.getDay()
+    const todayRoutineIds = effectiveRoutineIds(S, isoToday)
+    const todayRoutines = effectiveRoutines(S, isoToday)
     return {
       today: isoToday,
       weekdays: [0, 1, 2, 3, 4, 5, 6].map(d => {
@@ -159,8 +161,12 @@ export const getWeekPlan = {
           override_for_today_or_null: overrideForToday
         }
       }),
-      today_routine_id: effectiveRoutineId(S, isoToday),
-      today_routine_name: effectiveRoutine(S, isoToday)?.name || null
+      // Keep the original singular fields for existing MCP clients; the plural fields expose
+      // every startable plan when a date has a multi-routine override.
+      today_routine_ids: todayRoutineIds,
+      today_routine_names: todayRoutines.map(r => r.name),
+      today_routine_id: todayRoutineIds[0] || null,
+      today_routine_name: todayRoutines[0]?.name || null
     }
   }
 }

--- a/mcp/test/tools.test.js
+++ b/mcp/test/tools.test.js
@@ -183,6 +183,18 @@ describe('get_week_plan', () => {
     expect(r.today_routine_name).toBe('Leg Day')
   })
 
+  test('a multi-plan override exposes every routine while keeping singular fields compatible', () => {
+    const legs = S.routines.find(r => r.name === 'Leg Day')
+    const push = S.routines.find(r => r.name === 'Push Day')
+    S.dayPlan[FAKE_TODAY_ISO] = [legs.id, push.id]
+
+    const r = call('get_week_plan')
+    expect(r.today_routine_ids).toEqual([legs.id, push.id])
+    expect(r.today_routine_names).toEqual(['Leg Day', 'Push Day'])
+    expect(r.today_routine_id).toBe(legs.id)
+    expect(r.today_routine_name).toBe('Leg Day')
+  })
+
   test('empty week + no override → today has no routine (a quiet Sunday)', () => {
     S.week = {}
     S.dayPlan = {}


### PR DESCRIPTION
## Multiple plans per day — pick more than one routine for a date

A day can now run two or more routines (morning + evening, or any mix), selected with a clear order.

**What's here:**
- **Ordered multi-select from the plan page** — tap any weekday, then tap routines; each selection gets a tick and an order number (1, 2, 3…) in the order you pressed them. The plan page's day rows show every selected program (green tags, order numbers, max two rows).
- **Session picker on start** — when a day has several planned sessions, starting a workout shows a small picker: sessions side by side, the first *uncompleted* one pre-selected, completed ones greyed out with a tick. Single-plan days start straight from their card.
- **Legacy data preserved** — old scalar day overrides migrate to lists on load; `['rest']` stays an explicit rest day; "back to weekly plan" still works.
- **Order is the model** — no named morning/evening slots; the stored list order is the order sessions are offered.
- **API sync fix** — the server's reminder suppression now matches the frontend's weekly fallback for migrated overrides.
- **Sheet host: Android back closes popups** (issue #63) — every sheet pushes a history entry, Back dismisses the top sheet instead of leaving the page; plus mouse-drag swipe-to-dismiss and Esc for desktop.
- Tests for migration, order preservation, rest semantics and the weekly fallback; MCP singular/plural compatibility kept.

Verified on a live deployment (owner-tested) before opening.