### PR TITLE
Muscle map: derive the secondary-muscle overlay without mutating the dataset

### DIFF
--- a/frontend/src/lib/exercises.js
+++ b/frontend/src/lib/exercises.js
@@ -13,12 +13,17 @@ const SECONDARY_ADDITIONS = {
   '0861': ['rear deltoids'], // cable seated row
 }
 
+// Secondary muscles for an exercise, with the small conservative additions applied as an
+// overlay. The raw dataset is never mutated - consumers that want the pristine catalogue
+// (export, print, import) keep reading EXDB untouched, while the muscle map sees the
+// enriched list. Values follow the dataset's existing alias vocabulary.
+export const smOf = ex => {
+  const base = Array.isArray(ex?.sm) ? ex.sm : (ex?.sm ? [ex.sm] : [])
+  return [...new Set([...base, ...(SECONDARY_ADDITIONS[ex?.id] || [])])]
+}
+
 export const EXIDX = {}
-EXDB.forEach(e => {
-  const additions = SECONDARY_ADDITIONS[e.id]
-  if (additions) e.sm = [...new Set([...(e.sm || []), ...additions])]
-  EXIDX[e.id] = e
-})
+EXDB.forEach(e => { EXIDX[e.id] = e })
 export const BODYPARTS = [...new Set(EXDB.map(e => e.bp))].sort()
 
 // Equipment options present in a given list of exercises, most common first (issue #6).

--- a/frontend/src/lib/muscles.js
+++ b/frontend/src/lib/muscles.js
@@ -7,7 +7,7 @@
 // map can actually draw, via ALIAS below. Anything genuinely undrawable (hands,
 // ankles, "cardiovascular system") maps to null and is dropped rather than guessed at.
 
-import { EXIDX } from './exercises.js'
+import { EXIDX , smOf } from './exercises.js'
 
 // The muscles a map can shade, in head-to-toe order — also the order of any list
 // built from them, so "what am I neglecting" reads top-down like a body.
@@ -78,7 +78,7 @@ export function musclesOf(ex) {
     if (slug) out[slug] = Math.max(out[slug] || 0, w)
   }
   add(ex.tg, 1)
-  ;(ex.sm || []).forEach(m => add(m, SECONDARY))
+  ;smOf(ex).forEach(m => add(m, SECONDARY))
   // Nothing recognised (custom exercises, or a target we don't draw) — use the body part.
   if (!Object.keys(out).length) Object.assign(out, BY_BODYPART[ex.bp] || {})
   return out

--- a/frontend/src/lib/muscles.test.js
+++ b/frontend/src/lib/muscles.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { EXIDX } from './exercises.js'
+import { EXIDX, EXDB, smOf } from './exercises.js'
 import { musclesOf } from './muscles.js'
 
 // The catalogue keeps the source dataset's secondary-muscle spellings; musclesOf maps
@@ -29,5 +29,16 @@ describe('catalogue secondary muscles', () => {
         deltoids: 0.4,
       })
     }
+  })
+})
+
+
+describe('catalogue secondary additions', () => {
+  it('enriches the muscle map without mutating the raw dataset', () => {
+    const raw = EXDB.find(e => e.id === '0027')
+    expect(raw.sm).not.toContain('rear deltoids')
+    expect(smOf(raw)).toContain('rear deltoids')
+    // the alias collapses onto the deltoids slug in the canonical muscle map
+    expect(musclesOf(raw)).toHaveProperty('deltoids')
   })
 })


### PR DESCRIPTION
## Muscle catalogue secondary groups — overlay without mutation

`smOf` produces a fresh, de-duplicated overlay of catalogue + custom secondary muscle groups; `EXDB`/`EXIDX` are no longer mutated, and `musclesOf` is the only consumer. Catalogue, custom and string-valued secondary entries all stay safe.

Verified on a live deployment before opening.