### PR TITLE
fix: back button dismisses sheets instead of leaving the page (#63)

### DIFF
--- a/frontend/src/components/Modals.jsx
+++ b/frontend/src/components/Modals.jsx
@@ -35,13 +35,38 @@ function Sheet({ sheet }) {
     else el.style.transform = ''
     d.startY = null
   }
+  // Mouse drag (desktop testing / trackpads): same swipe-to-dismiss behaviour.
+  const onMouseDown = e => {
+    if (e.button !== 0) return
+    if (e.target.closest && e.target.closest('input[type=range], [data-nodrag]')) {
+      drag.current = { startY: null, delta: 0 }
+      return
+    }
+    const el = ref.current
+    drag.current = { startY: el.scrollTop <= 0 ? e.clientY : null, delta: 0 }
+  }
+  const onMouseMove = e => {
+    const el = ref.current, d = drag.current
+    if (d.startY === null) return
+    d.delta = e.clientY - d.startY
+    if (d.delta > 0 && el.scrollTop <= 0) {
+      e.preventDefault()
+      el.style.transition = 'none'
+      el.style.transform = `translateY(${d.delta}px)`
+    } else d.delta = 0
+  }
+  const onMouseUp = () => onTouchEnd()
 
   // non-passive touchmove so preventDefault works (bottom sheets only; centered dialogs have no ref)
   useEffect(() => {
     const el = ref.current
     if (!el) return
     el.addEventListener('touchmove', onTouchMove, { passive: false })
-    return () => el.removeEventListener('touchmove', onTouchMove)
+    window.addEventListener('mouseup', onMouseUp)
+    return () => {
+      el.removeEventListener('touchmove', onTouchMove)
+      window.removeEventListener('mouseup', onMouseUp)
+    }
   }, [])
 
   const close = () => closeSheet(sheet.id)
@@ -56,7 +81,8 @@ function Sheet({ sheet }) {
   return (
     <div>
       <div className="mback" onClick={() => { if (!sheet.locked) close() }} />
-      <div className="sheet" ref={ref} onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
+      <div className="sheet" ref={ref} onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}
+        onMouseDown={onMouseDown} onMouseMove={onMouseMove} onMouseUp={onMouseUp} onMouseLeave={onMouseUp}>
         <div className="grab" />
         {sheet.render(close)}
       </div>
@@ -66,8 +92,67 @@ function Sheet({ sheet }) {
 
 export default function Modals() {
   const sheets = useUI(s => s.sheets)
+  const closeSheet = useUI(s => s.closeSheet)
+  const prevLen = useRef(0)
+  const suppressPop = useRef(false)
+  const pushedEntries = useRef(0)
+  const sheetEntries = useRef([])
+
+  // Every opened sheet gets a history entry so Android back dismisses it instead of
+  // leaving the page (issue #63). Keep the pushed-entry count and each active sheet's
+  // live-entry status explicit: sheet count cannot tell whether popstate already spent
+  // an entry (especially for a locked sheet) or whether several sheets opened at once.
+  useEffect(() => {
+    const prev = prevLen.current
+    prevLen.current = sheets.length
+    if (sheets.length > prev) {
+      for (let i = prev; i < sheets.length; i++) {
+        sheetEntries.current.push({ openedAt: location.href, live: true })
+        history.pushState({ openGymSheet: true }, '')
+        pushedEntries.current++
+      }
+    } else if (sheets.length < prev) {
+      const closedEntries = sheetEntries.current.splice(sheets.length, prev - sheets.length)
+      const rewind = closedEntries.filter(entry =>
+        entry.live && !(typeof entry.openedAt === 'string' && location.href !== entry.openedAt)).length
+      if (rewind > 0) {
+        pushedEntries.current = Math.max(0, pushedEntries.current - rewind)
+        suppressPop.current = true
+        history.go(-rewind)
+      }
+      // Entries skipped because the app moved on remain in pushedEntries as deliberate
+      // leaks until a later popstate consumes them with no corresponding active sheet.
+    }
+  }, [sheets.length])
+
+  useEffect(() => {
+    const onPop = () => {
+      if (suppressPop.current) { suppressPop.current = false; return }
+      if (pushedEntries.current <= 0) return
+      pushedEntries.current--
+      // The browser has already spent one pushed entry. Mark the latest live active
+      // sheet entry spent even when the sheet is locked; with no active entry this is a
+      // moved-on leak, which is still accounted for by the counter decrement above.
+      for (let i = sheetEntries.current.length - 1; i >= 0; i--) {
+        if (sheetEntries.current[i].live) {
+          sheetEntries.current[i].live = false
+          break
+        }
+      }
+      const top = sheets[sheets.length - 1]
+      if (top && !top.locked) closeSheet(top.id)
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [sheets, closeSheet])
 
   // lock the page behind any open sheet (iOS-safe)
+  useEffect(() => {
+    if (!sheets.length) return
+    const onKey = e => { if (e.key === 'Escape') { const top = useUI.getState().sheets[useUI.getState().sheets.length - 1]; if (top && !top.locked) useUI.getState().closeSheet(top.id) } }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [sheets.length])
   useEffect(() => {
     if (!sheets.length) return
     const y = window.scrollY || 0

--- a/frontend/src/components/Modals.test.jsx
+++ b/frontend/src/components/Modals.test.jsx
@@ -1,0 +1,201 @@
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { parseHTML } from 'linkedom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Modals from './Modals.jsx'
+
+const mocks = vi.hoisted(() => {
+  const listeners = new Set()
+  const state = {
+    sheets: [],
+    closeSheet(id) {
+      state.sheets = state.sheets.filter(sheet => sheet.id !== id)
+      listeners.forEach(listener => listener())
+    },
+  }
+  return {
+    state,
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    setSheets(sheets) {
+      state.sheets = sheets
+      listeners.forEach(listener => listener())
+    },
+  }
+})
+
+vi.mock('../store/useUI.js', async () => {
+  const React = await import('react')
+  const useUI = (selector = state => state) => React.useSyncExternalStore(
+    mocks.subscribe,
+    () => selector(mocks.state),
+    () => selector(mocks.state),
+  )
+  useUI.getState = () => mocks.state
+  return { useUI }
+})
+
+let dom
+let root
+let container
+let historyMock
+let locationMock
+
+function sheet(id, { locked = false, render = () => React.createElement('div') } = {}) {
+  return { id, locked, kind: 'sheet', render }
+}
+
+function installDom() {
+  const parsed = parseHTML('<!doctype html><html><body><div id="root"></div></body></html>')
+  dom = parsed.window
+  dom.scrollTo = vi.fn()
+  globalThis.window = dom
+  globalThis.document = dom.document
+  Object.defineProperty(globalThis, 'navigator', { configurable: true, value: dom.navigator })
+  for (const key of ['HTMLElement', 'Node', 'Element', 'Event']) globalThis[key] = dom[key]
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+  locationMock = { href: 'https://opengym.test/#/workout' }
+  historyMock = { pushState: vi.fn(), go: vi.fn() }
+  Object.defineProperty(globalThis, 'location', { configurable: true, value: locationMock })
+  Object.defineProperty(globalThis, 'history', { configurable: true, value: historyMock })
+
+  container = document.getElementById('root')
+  root = createRoot(container)
+}
+
+async function setSheets(sheets) {
+  await act(async () => { mocks.setSheets(sheets) })
+}
+
+async function popstate() {
+  await act(async () => { window.dispatchEvent(new dom.Event('popstate')) })
+}
+
+function mouse(target, type, clientY) {
+  const event = new dom.Event(type, { bubbles: true })
+  Object.defineProperties(event, {
+    button: { value: 0 },
+    clientY: { value: clientY },
+  })
+  target.dispatchEvent(event)
+}
+
+beforeEach(async () => {
+  mocks.state.sheets = []
+  installDom()
+  await act(async () => { root.render(React.createElement(Modals)) })
+})
+
+afterEach(async () => {
+  if (root) await act(async () => { root.unmount() })
+  root = null
+  container = null
+  dom = null
+  vi.restoreAllMocks()
+})
+
+describe('Modals sheet history accounting', () => {
+  it('does not rewind a real page after back spends a locked FinishSummary entry', async () => {
+    const confirm = sheet('confirm')
+    const summary = sheet('summary', { locked: true })
+
+    await setSheets([confirm])
+    expect(historyMock.pushState).toHaveBeenCalledTimes(1)
+
+    // ConfirmDialog closes and FinishSummary opens in the same batch: length remains one,
+    // so the existing pushed entry now belongs to the locked summary.
+    await setSheets([summary])
+    await popstate()
+    expect(mocks.state.sheets).toEqual([summary])
+
+    await act(async () => { mocks.state.closeSheet('summary') })
+    expect(historyMock.go).not.toHaveBeenCalled()
+  })
+
+  it('pushes and rewinds the exact number of entries for batched sheets', async () => {
+    await setSheets([sheet('one'), sheet('two')])
+    expect(historyMock.pushState).toHaveBeenCalledTimes(2)
+
+    await setSheets([])
+    expect(historyMock.go).toHaveBeenCalledTimes(1)
+    expect(historyMock.go).toHaveBeenCalledWith(-2)
+  })
+
+  it('closes stacked sheets one entry at a time on back', async () => {
+    await setSheets([sheet('one'), sheet('two')])
+    await popstate()
+
+    expect(mocks.state.sheets.map(item => item.id)).toEqual(['one'])
+    expect(historyMock.pushState).toHaveBeenCalledTimes(2)
+
+    await popstate()
+    expect(mocks.state.sheets).toEqual([])
+    expect(historyMock.go).not.toHaveBeenCalled()
+  })
+
+  it('closes an unlocked sheet on back without rewinding its already-spent entry', async () => {
+    await setSheets([sheet('open')])
+    await popstate()
+
+    expect(mocks.state.sheets).toEqual([])
+    expect(historyMock.go).not.toHaveBeenCalled()
+  })
+
+  it('accounts for a moved-on entry even when popstate has no current sheet', async () => {
+    await setSheets([sheet('navigating')])
+    locationMock.href = 'https://opengym.test/#/home'
+    await setSheets([])
+    expect(historyMock.go).not.toHaveBeenCalled()
+
+    // This spends the deliberately leaked entry with top === undefined.
+    await popstate()
+
+    const locked = sheet('locked', { locked: true })
+    await setSheets([locked])
+    await popstate()
+    await setSheets([])
+    expect(historyMock.go).not.toHaveBeenCalled()
+  })
+})
+
+describe('Modals mouse dragging', () => {
+  it('leaves range sliders opted out of sheet dragging', async () => {
+    await setSheets([sheet('slider', {
+      render: () => React.createElement('input', { type: 'range' }),
+    })])
+    const sheetEl = container.querySelector('.sheet')
+    const slider = container.querySelector('input[type="range"]')
+    sheetEl.scrollTop = 0
+
+    await act(async () => {
+      mouse(slider, 'mousedown', 10)
+      mouse(sheetEl, 'mousemove', 150)
+      window.dispatchEvent(new dom.Event('mouseup'))
+    })
+
+    expect(sheetEl.style.transform).toBe('')
+    expect(mocks.state.sheets).toHaveLength(1)
+  })
+
+  it('releases a drag when mouseup occurs outside the sheet', async () => {
+    await setSheets([sheet('drag')])
+    const sheetEl = container.querySelector('.sheet')
+    sheetEl.scrollTop = 0
+
+    await act(async () => {
+      mouse(sheetEl, 'mousedown', 10)
+      mouse(sheetEl, 'mousemove', 60)
+    })
+    expect(sheetEl.style.transform).toBe('translateY(50px)')
+
+    await act(async () => { window.dispatchEvent(new dom.Event('mouseup')) })
+    expect(sheetEl.style.transform).toBe('')
+
+    await act(async () => { mouse(sheetEl, 'mousemove', 120) })
+    expect(sheetEl.style.transform).toBe('')
+    expect(mocks.state.sheets).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Back button closes sheets instead of leaving the page

Fixes #63. On Android (and any browser with a back gesture) the back button used to leave the current route while a bottom sheet was open - or close the whole app when nothing was stacked - even though the sheet host already supported swipe-to-dismiss.

What this does:

- Every open sheet now **pushes a history entry**, so the back button dismisses the top sheet (locked sheets are left alone, as discussed)
- A normal close **pops its own entry**, and a swipe-dismissed sheet leaves the stack exactly like a back-dismissed one - so back never starts skipping pages a screen or two later
- If the app navigated while the sheet was open (e.g. starting a workout from the check-in), the close does **not** rewind history, so it can't silently undo that navigation
- Escape on desktop and a mouse drag on trackpads get the same dismiss behaviour

One file, ~65 lines, no dependencies.