### PR TITLE
feat: multi-primary muscle model with ExRx compound + machine batches

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opengym-frontend",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opengym-frontend",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@capacitor/core": "^7.6.8",

--- a/frontend/src/components/ui.jsx
+++ b/frontend/src/components/ui.jsx
@@ -274,6 +274,39 @@ export function SelectRow({ icon, iconTint, title, value, options, onChange, she
   )
 }
 
+/** Multi-select row: shows the chosen values, opens a sheet where every option is a
+ * toggling row with a check. The sheet stays open so several can be picked at once;
+ * the caller's onToggle mutates the selection. */
+export function MultiSelectRow({ icon, iconTint, title, values, options, onToggle, sheetTitle, noneLabel, doneLabel }) {
+  const selected = options.filter(o => values.includes(o.value))
+  const summary = selected.length ? selected.map(o => o.label).join(', ') : (noneLabel || '')
+  const open = () => {
+    const { openSheet } = require_ui()
+    openSheet(close => (
+      <>
+        <h3>{sheetTitle || title}</h3>
+        <div className="sect-b">
+          {options.map(o => {
+            const on = values.includes(o.value)
+            return (
+              <button key={o.value} className={'lrow tap' + (on ? ' on' : '')} onClick={() => onToggle(o.value)}>
+                <span className="lrow-m"><span className="lrow-t">{o.label}</span>
+                  {o.subtitle && <span className="lrow-s">{o.subtitle}</span>}</span>
+                {on && <Icon name="check" className="lrow-k" />}
+              </button>
+            )
+          })}
+        </div>
+        <div style={{ height: 8 }} />
+        <Button variant="primary" onClick={close}>{doneLabel || 'Done'}</Button>
+      </>
+    ))
+  }
+  return (
+    <Row icon={icon} iconTint={iconTint} title={title} value={summary} accessory="chevron" onClick={open} />
+  )
+}
+
 // Late import keeps this module free of a cycle at load time (useUI pulls in the
 // store, which pulls in helpers that import controls).
 let _ui = null

--- a/frontend/src/lib/exercise-muscle-batch-1.js
+++ b/frontend/src/lib/exercise-muscle-batch-1.js
@@ -1,0 +1,27 @@
+import batch from './exercise-muscle-batch-1.json' with { type: 'json' }
+import { MACHINE_BATCH_2 } from './exercise-muscle-batch-2.js'
+
+/**
+ * ExRx-informed metadata for the first compound-lift batch. The raw generated catalogue remains
+ * untouched; exercises.js applies this layer to the runtime index.
+ */
+export const COMPOUND_LIFT_BATCH_1 = Object.freeze(batch)
+
+// Keep the phase-2 artifact in its own module for auditing while preserving the phase-1 resolver
+// interface consumed by exercises.js and downstream muscle helpers.
+export { MACHINE_BATCH_2 }
+
+/**
+ * Reserved for owner-approved corrections. This layer is intentionally separate from the
+ * generated batch so a correction can replace a generated body part or muscle list without
+ * editing generated data. Explicit metadata on a user/custom exercise wins as well.
+ */
+export const USER_EXERCISE_MUSCLE_OVERRIDES = Object.freeze({})
+
+export function exerciseMuscleMetadataFor(id) {
+  return {
+    ...(COMPOUND_LIFT_BATCH_1[id] || {}),
+    ...(MACHINE_BATCH_2[id] || {}),
+    ...(USER_EXERCISE_MUSCLE_OVERRIDES[id] || {})
+  }
+}

--- a/frontend/src/lib/exercise-muscle-batch-1.json
+++ b/frontend/src/lib/exercise-muscle-batch-1.json
@@ -1,0 +1,1293 @@
+{
+  "0043": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "1461": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "1462": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0042": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0029": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "1436": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "1435": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0127": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0063": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0124": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0099": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0068": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "1760": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0413": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0533": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0534": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0755": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0770": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0852": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0069": {
+    "bp": "full body",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "lower-back",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0786": {
+    "bp": "full body",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors",
+      "deltoids"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves",
+      "triceps",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0032": {
+    "bp": "full body",
+    "primaries": [
+      "gluteal",
+      "hamstring",
+      "lower-back"
+    ],
+    "secondaries": [
+      "quadriceps",
+      "adductors",
+      "calves",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0117": {
+    "bp": "full body",
+    "primaries": [
+      "gluteal",
+      "hamstring",
+      "lower-back"
+    ],
+    "secondaries": [
+      "quadriceps",
+      "adductors",
+      "calves",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0066": {
+    "bp": "full body",
+    "primaries": [
+      "gluteal",
+      "hamstring",
+      "lower-back"
+    ],
+    "secondaries": [
+      "quadriceps",
+      "adductors",
+      "calves",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0157": {
+    "bp": "full body",
+    "primaries": [
+      "gluteal",
+      "hamstring",
+      "lower-back"
+    ],
+    "secondaries": [
+      "quadriceps",
+      "adductors",
+      "calves",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0752": {
+    "bp": "full body",
+    "primaries": [
+      "gluteal",
+      "hamstring",
+      "lower-back"
+    ],
+    "secondaries": [
+      "quadriceps",
+      "adductors",
+      "calves",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0811": {
+    "bp": "full body",
+    "primaries": [
+      "gluteal",
+      "hamstring",
+      "lower-back"
+    ],
+    "secondaries": [
+      "quadriceps",
+      "adductors",
+      "calves",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0085": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "1756": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "0300": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "1459": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "1757": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "2805": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "0432": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "0434": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "0578": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "0116": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "1010": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back",
+      "quadriceps",
+      "adductors",
+      "calves"
+    ]
+  },
+  "0025": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0033": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0045": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0047": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0122": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "1256": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "1257": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "1254": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0151": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0169": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0289": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0301": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0314": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0748": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0030": {
+    "bp": "upper arms",
+    "primaries": [
+      "triceps"
+    ],
+    "secondaries": [
+      "chest",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0751": {
+    "bp": "upper arms",
+    "primaries": [
+      "triceps"
+    ],
+    "secondaries": [
+      "chest",
+      "deltoids",
+      "biceps"
+    ]
+  },
+  "0091": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "1456": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "1457": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0086": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0997": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0219": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0148": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0405": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0404": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0426": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0587": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0765": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0774": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "1012": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "triceps",
+      "trapezius",
+      "abs",
+      "obliques"
+    ]
+  },
+  "0414": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "triceps",
+      "trapezius",
+      "abs"
+    ]
+  },
+  "0027": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0049": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0064": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "3017": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0118": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "1317": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0988": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0990": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0159": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0180": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0189": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0861": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0213": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0214": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0218": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0234": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0293": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0292": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0499": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0808": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0652": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0651": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "1326": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "1327": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0253": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0627": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0638": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0017": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0015": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "1431": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "1432": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0970": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "0841": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "1429": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm"
+    ]
+  },
+  "3418": {
+    "bp": "full body",
+    "primaries": [
+      "upper-back",
+      "abs"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "hip-flexors"
+    ]
+  }
+}

--- a/frontend/src/lib/exercise-muscle-batch-1.test.js
+++ b/frontend/src/lib/exercise-muscle-batch-1.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { BODYPARTS, EXDB, EXIDX, registerCustom } from './exercises.js'
+import { COMPOUND_LIFT_BATCH_1 } from './exercise-muscle-batch-1.js'
+import { MUSCLES, musclesOf } from './muscles.js'
+
+const ids = Object.keys(COMPOUND_LIFT_BATCH_1)
+const catalogueIds = new Set(EXDB.map(ex => ex.id))
+
+const duplicateFree = values => values.length === new Set(values).size
+
+describe('compound-lift muscle metadata batch 1', () => {
+  it('contains a bounded first batch of compound-lift catalogue entries', () => {
+    expect(ids.length).toBeGreaterThanOrEqual(60)
+    expect(ids.length).toBeLessThanOrEqual(120)
+    expect(ids.every(id => catalogueIds.has(id))).toBe(true)
+  })
+
+  it('stores canonical primary and secondary arrays for every batch entry', () => {
+    for (const [id, metadata] of Object.entries(COMPOUND_LIFT_BATCH_1)) {
+      expect(metadata.primaries.length, id).toBeGreaterThan(0)
+      expect(duplicateFree(metadata.primaries), id).toBe(true)
+      expect(duplicateFree(metadata.secondaries), id).toBe(true)
+      expect(metadata.primaries.some(muscle => metadata.secondaries.includes(muscle)), id).toBe(false)
+      expect(metadata.primaries.every(muscle => MUSCLES.includes(muscle)), id).toBe(true)
+      expect(metadata.secondaries.every(muscle => MUSCLES.includes(muscle)), id).toBe(true)
+      expect(EXIDX[id]).toMatchObject(metadata)
+    }
+  })
+
+  it('follows the documented ExRx family templates and preserves source-known muscles', () => {
+    expect(COMPOUND_LIFT_BATCH_1['0043']).toEqual({
+      bp: 'upper legs',
+      primaries: ['quadriceps', 'gluteal', 'adductors'],
+      secondaries: ['hamstring', 'calves', 'lower-back', 'abs', 'obliques']
+    })
+    expect(COMPOUND_LIFT_BATCH_1['0032']).toEqual({
+      bp: 'full body',
+      primaries: ['gluteal', 'hamstring', 'lower-back'],
+      secondaries: ['quadriceps', 'adductors', 'calves', 'abs', 'obliques']
+    })
+    expect(COMPOUND_LIFT_BATCH_1['0025']).toEqual({
+      bp: 'chest', primaries: ['chest'], secondaries: ['triceps', 'deltoids', 'biceps']
+    })
+    expect(COMPOUND_LIFT_BATCH_1['0091']).toEqual({
+      bp: 'shoulders', primaries: ['deltoids'],
+      secondaries: ['chest', 'triceps', 'trapezius', 'serratus']
+    })
+    expect(COMPOUND_LIFT_BATCH_1['0027']).toEqual({
+      bp: 'back', primaries: ['upper-back'],
+      secondaries: ['biceps', 'deltoids', 'forearm']
+    })
+    expect(COMPOUND_LIFT_BATCH_1['0652']).toEqual({
+      bp: 'back', primaries: ['upper-back'], secondaries: ['biceps', 'deltoids', 'forearm']
+    })
+    expect(musclesOf(EXDB.find(exercise => exercise.id === '0587'))).toMatchObject({ chest: 0.4 })
+    expect(musclesOf(EXIDX['0587'])).toMatchObject({ chest: 0.4 })
+  })
+
+  it('keeps torso bracing secondary and does not label the twisting press full body', () => {
+    expect(COMPOUND_LIFT_BATCH_1['0414']).toEqual({
+      bp: 'shoulders', primaries: ['deltoids'], secondaries: ['triceps', 'trapezius', 'abs']
+    })
+    expect(COMPOUND_LIFT_BATCH_1['1012']).toEqual({
+      bp: 'shoulders', primaries: ['deltoids'],
+      secondaries: ['triceps', 'trapezius', 'abs', 'obliques']
+    })
+    expect(COMPOUND_LIFT_BATCH_1['1012'].primaries).not.toContain('abs')
+    expect(COMPOUND_LIFT_BATCH_1['1012'].secondaries).toContain('obliques')
+  })
+
+  it('marks the cross-region lifts as Full body while keeping classic areas available', () => {
+    expect(EXIDX['0069']).toMatchObject({ bp: 'full body', primaries: ['quadriceps', 'gluteal', 'adductors'] })
+    expect(EXIDX['0032'].bp).toBe('full body')
+    expect(BODYPARTS).toContain('full body')
+    expect(EXIDX['0025'].bp).toBe('chest')
+    expect(EXIDX['0652'].bp).toBe('back')
+  })
+
+  it('lets an explicit user exercise override the batch and restores the catalogue afterward', () => {
+    registerCustom([{ id: '0025', n: 'Owner bench correction', bp: 'chest', primaries: ['triceps'], secondaries: [] }])
+    expect(EXIDX['0025']).toMatchObject({ primaries: ['triceps'], secondaries: [] })
+    registerCustom([])
+    expect(EXIDX['0025']).toMatchObject(COMPOUND_LIFT_BATCH_1['0025'])
+  })
+})

--- a/frontend/src/lib/exercise-muscle-batch-2.js
+++ b/frontend/src/lib/exercise-muscle-batch-2.js
@@ -1,0 +1,8 @@
+import batch from './exercise-muscle-batch-2.json' with { type: 'json' }
+
+/**
+ * ExRx-informed metadata for machine, cable, sled, and Smith-machine catalogue entries.
+ * `exercises.js` applies this as a runtime overlay so the raw generated catalogue remains
+ * compatible with imports and historical records.
+ */
+export const MACHINE_BATCH_2 = Object.freeze(batch)

--- a/frontend/src/lib/exercise-muscle-batch-2.json
+++ b/frontend/src/lib/exercise-muscle-batch-2.json
@@ -1,0 +1,1310 @@
+{
+  "0596": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "deltoids",
+      "biceps",
+      "serratus"
+    ]
+  },
+  "0577": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "deltoids",
+      "triceps",
+      "biceps"
+    ]
+  },
+  "0576": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "deltoids",
+      "triceps",
+      "biceps"
+    ]
+  },
+  "1300": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "deltoids",
+      "triceps",
+      "biceps"
+    ]
+  },
+  "1299": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "deltoids",
+      "triceps",
+      "biceps"
+    ]
+  },
+  "1479": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "deltoids",
+      "triceps",
+      "biceps"
+    ]
+  },
+  "3758": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "deltoids",
+      "triceps",
+      "biceps"
+    ]
+  },
+  "1301": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "deltoids",
+      "triceps",
+      "biceps"
+    ]
+  },
+  "2144": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "deltoids",
+      "triceps",
+      "biceps"
+    ]
+  },
+  "0155": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "upper-back",
+      "trapezius"
+    ]
+  },
+  "0158": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "upper-back",
+      "trapezius"
+    ]
+  },
+  "0171": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "upper-back",
+      "trapezius"
+    ]
+  },
+  "0179": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "upper-back",
+      "trapezius"
+    ]
+  },
+  "0185": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "upper-back",
+      "trapezius"
+    ]
+  },
+  "0188": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "upper-back",
+      "trapezius"
+    ]
+  },
+  "0227": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "upper-back",
+      "trapezius"
+    ]
+  },
+  "1269": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "upper-back",
+      "trapezius"
+    ]
+  },
+  "1270": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "upper-back",
+      "trapezius"
+    ]
+  },
+  "0009": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids"
+    ]
+  },
+  "2364": {
+    "bp": "chest",
+    "primaries": [
+      "chest"
+    ],
+    "secondaries": [
+      "triceps",
+      "deltoids"
+    ]
+  },
+  "0019": {
+    "bp": "upper arms",
+    "primaries": [
+      "triceps"
+    ],
+    "secondaries": [
+      "deltoids",
+      "chest",
+      "upper-back",
+      "trapezius",
+      "biceps"
+    ]
+  },
+  "1451": {
+    "bp": "upper arms",
+    "primaries": [
+      "triceps"
+    ],
+    "secondaries": [
+      "deltoids",
+      "chest",
+      "upper-back",
+      "trapezius",
+      "biceps"
+    ]
+  },
+  "0607": {
+    "bp": "upper arms",
+    "primaries": [
+      "triceps"
+    ],
+    "secondaries": []
+  },
+  "0007": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0150": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0153": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "2330": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0177": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "2616": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "3563": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0198": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0197": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0205": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0245": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "1325": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0579": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "1347": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "2736": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0673": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0818": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "triceps"
+    ]
+  },
+  "0167": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "0193": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "0208": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "0236": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "0239": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "1320": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "1321": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "1323": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "0571": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "0588": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "1350": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "3200": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "0606": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "1349": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "1313": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "1318": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "1324": {
+    "bp": "back",
+    "primaries": [
+      "upper-back"
+    ],
+    "secondaries": [
+      "biceps",
+      "deltoids",
+      "forearm",
+      "trapezius",
+      "chest",
+      "triceps"
+    ]
+  },
+  "2287": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "2611": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "1425": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "0739": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "1464": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "1463": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "0740": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "0741": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "0743": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "0744": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "0760": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "3281": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "1434": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "3142": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "0768": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "0769": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps",
+      "gluteal",
+      "adductors"
+    ],
+    "secondaries": [
+      "hamstring",
+      "calves"
+    ]
+  },
+  "0585": {
+    "bp": "upper legs",
+    "primaries": [
+      "quadriceps"
+    ],
+    "secondaries": []
+  },
+  "3235": {
+    "bp": "upper legs",
+    "primaries": [
+      "hamstring"
+    ],
+    "secondaries": [
+      "calves"
+    ]
+  },
+  "0582": {
+    "bp": "upper legs",
+    "primaries": [
+      "hamstring"
+    ],
+    "secondaries": [
+      "calves"
+    ]
+  },
+  "0586": {
+    "bp": "upper legs",
+    "primaries": [
+      "hamstring"
+    ],
+    "secondaries": [
+      "calves"
+    ]
+  },
+  "3195": {
+    "bp": "upper legs",
+    "primaries": [
+      "hamstring"
+    ],
+    "secondaries": [
+      "calves"
+    ]
+  },
+  "0599": {
+    "bp": "upper legs",
+    "primaries": [
+      "hamstring"
+    ],
+    "secondaries": [
+      "calves",
+      "adductors"
+    ]
+  },
+  "0590": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0603": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus",
+      "biceps"
+    ]
+  },
+  "0869": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "2318": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0766": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0772": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "chest",
+      "triceps",
+      "trapezius",
+      "serratus"
+    ]
+  },
+  "0601": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "trapezius",
+      "upper-back"
+    ]
+  },
+  "0602": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "trapezius",
+      "upper-back"
+    ]
+  },
+  "0762": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "trapezius",
+      "upper-back"
+    ]
+  },
+  "0154": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "trapezius",
+      "upper-back"
+    ]
+  },
+  "0202": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "trapezius",
+      "upper-back"
+    ]
+  },
+  "0203": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "trapezius",
+      "upper-back"
+    ]
+  },
+  "0584": {
+    "bp": "shoulders",
+    "primaries": [
+      "deltoids"
+    ],
+    "secondaries": [
+      "trapezius",
+      "upper-back"
+    ]
+  },
+  "1375": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "1376": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "1383": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "1384": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "1253": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "0594": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "1385": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "0605": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "0742": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "1393": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "0763": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "1394": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "1395": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "0773": {
+    "bp": "lower legs",
+    "primaries": [
+      "calves"
+    ],
+    "secondaries": []
+  },
+  "0597": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal"
+    ],
+    "secondaries": [
+      "hamstring"
+    ]
+  },
+  "0598": {
+    "bp": "upper legs",
+    "primaries": [
+      "adductors"
+    ],
+    "secondaries": [
+      "gluteal",
+      "hamstring"
+    ]
+  },
+  "0168": {
+    "bp": "upper legs",
+    "primaries": [
+      "adductors"
+    ],
+    "secondaries": [
+      "gluteal",
+      "hamstring"
+    ]
+  },
+  "0228": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal"
+    ],
+    "secondaries": [
+      "hamstring"
+    ]
+  },
+  "0196": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal"
+    ],
+    "secondaries": [
+      "hamstring"
+    ]
+  },
+  "0573": {
+    "bp": "back",
+    "primaries": [
+      "lower-back"
+    ],
+    "secondaries": [
+      "gluteal",
+      "hamstring"
+    ]
+  },
+  "0593": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring"
+    ],
+    "secondaries": [
+      "lower-back"
+    ]
+  },
+  "3759": {
+    "bp": "upper legs",
+    "primaries": [
+      "gluteal",
+      "hamstring",
+      "lower-back"
+    ],
+    "secondaries": []
+  },
+  "0575": {
+    "bp": "upper arms",
+    "primaries": [
+      "biceps"
+    ],
+    "secondaries": [
+      "forearm"
+    ]
+  },
+  "1615": {
+    "bp": "upper arms",
+    "primaries": [
+      "biceps"
+    ],
+    "secondaries": [
+      "forearm"
+    ]
+  },
+  "0592": {
+    "bp": "upper arms",
+    "primaries": [
+      "biceps"
+    ],
+    "secondaries": [
+      "forearm"
+    ]
+  },
+  "1614": {
+    "bp": "upper arms",
+    "primaries": [
+      "biceps"
+    ],
+    "secondaries": [
+      "forearm"
+    ]
+  },
+  "1616": {
+    "bp": "upper arms",
+    "primaries": [
+      "biceps"
+    ],
+    "secondaries": [
+      "forearm"
+    ]
+  }
+}

--- a/frontend/src/lib/exercise-muscle-batch-2.test.js
+++ b/frontend/src/lib/exercise-muscle-batch-2.test.js
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import { BODYPARTS, EXDB, EXIDX, registerCustom } from './exercises.js'
+import { MACHINE_BATCH_2 } from './exercise-muscle-batch-2.js'
+import { MUSCLES, musclesOf } from './muscles.js'
+
+const ids = Object.keys(MACHINE_BATCH_2)
+const catalogue = new Map(EXDB.map(exercise => [exercise.id, exercise]))
+const duplicateFree = values => values.length === new Set(values).size
+
+const expectMapping = (id, expected) => {
+  expect(MACHINE_BATCH_2[id], id).toEqual(expected)
+  expect(EXIDX[id], id).toMatchObject(expected)
+}
+
+describe('machine muscle metadata batch 2', () => {
+  it('contains a bounded batch of machine and cable catalogue entries', () => {
+    expect(ids.length).toBeGreaterThanOrEqual(60)
+    expect(ids.length).toBeLessThanOrEqual(120)
+    expect(ids.length).toBe(119)
+    expect(ids.every(id => catalogue.has(id))).toBe(true)
+    expect(ids.every(id => /machine|cable/.test(catalogue.get(id).eq))).toBe(true)
+  })
+
+  it('uses only existing body-part keys and canonical drawable muscle slugs', () => {
+    for (const [id, metadata] of Object.entries(MACHINE_BATCH_2)) {
+      expect(BODYPARTS, id).toContain(metadata.bp)
+      expect(metadata.primaries.length, id).toBeGreaterThan(0)
+      expect(duplicateFree(metadata.primaries), id).toBe(true)
+      expect(duplicateFree(metadata.secondaries), id).toBe(true)
+      expect(metadata.primaries.some(muscle => metadata.secondaries.includes(muscle)), id).toBe(false)
+      expect(metadata.primaries.every(muscle => MUSCLES.includes(muscle)), id).toBe(true)
+      expect(metadata.secondaries.every(muscle => MUSCLES.includes(muscle)), id).toBe(true)
+      expect(EXIDX[id]).toMatchObject(metadata)
+    }
+  })
+
+  it('maps the pec-deck family from the lever seated-fly template', () => {
+    expectMapping('0596', {
+      bp: 'chest', primaries: ['chest'], secondaries: ['deltoids', 'biceps', 'serratus']
+    })
+  })
+
+  it('maps chest-press machines to chest with pressing assistants', () => {
+    expectMapping('0577', {
+      bp: 'chest', primaries: ['chest'], secondaries: ['deltoids', 'triceps', 'biceps']
+    })
+  })
+
+  it('maps cable crossovers to drawing-ready upper-back support', () => {
+    expectMapping('0155', {
+      bp: 'chest', primaries: ['chest'], secondaries: ['upper-back', 'trapezius']
+    })
+  })
+
+  it('maps machine/cable lat pulldowns to upper back with arm-and-shoulder synergy', () => {
+    expectMapping('0579', {
+      bp: 'back',
+      primaries: ['upper-back'],
+      secondaries: ['biceps', 'deltoids', 'forearm', 'trapezius', 'triceps']
+    })
+  })
+
+  it('maps seated rows to upper back with the phase-1 pull template', () => {
+    expectMapping('1350', {
+      bp: 'back',
+      primaries: ['upper-back'],
+      secondaries: ['biceps', 'deltoids', 'forearm', 'trapezius', 'chest', 'triceps']
+    })
+  })
+
+  it('maps assisted triceps dip variants to full synergist support', () => {
+    expectMapping('0019', {
+      bp: 'upper arms',
+      primaries: ['triceps'],
+      secondaries: ['deltoids', 'chest', 'upper-back', 'trapezius', 'biceps']
+    })
+    expectMapping('1451', {
+      bp: 'upper arms',
+      primaries: ['triceps'],
+      secondaries: ['deltoids', 'chest', 'upper-back', 'trapezius', 'biceps']
+    })
+  })
+
+  it('maps lever triceps extension without ExRx synergist secondaries', () => {
+    expectMapping('0607', {
+      bp: 'upper arms', primaries: ['triceps'], secondaries: []
+    })
+  })
+
+  it('maps sled leg presses to the multi-primary lower-body template', () => {
+    expectMapping('0739', {
+      bp: 'upper legs', primaries: ['quadriceps', 'gluteal', 'adductors'], secondaries: ['hamstring', 'calves']
+    })
+  })
+
+  it('maps leg extensions as quadriceps isolation', () => {
+    expectMapping('0585', {
+      bp: 'upper legs', primaries: ['quadriceps'], secondaries: []
+    })
+  })
+
+  it('maps seated leg curls to hamstrings with calf assistance', () => {
+    expectMapping('0599', {
+      bp: 'upper legs', primaries: ['hamstring'], secondaries: ['calves', 'adductors']
+    })
+  })
+
+  it('maps machine shoulder presses to deltoids with direct press support', () => {
+    expectMapping('0603', {
+      bp: 'shoulders', primaries: ['deltoids'],
+      secondaries: ['chest', 'triceps', 'trapezius', 'serratus', 'biceps']
+    })
+  })
+
+  it('preserves raw dataset metadata while enriching only the runtime catalogue', () => {
+    const raw = catalogue.get('0577')
+    expect(raw).toMatchObject({ id: '0577', n: 'lever chest press', tg: 'pectorals', mg: 'triceps' })
+    expect(raw).not.toHaveProperty('primaries')
+    expect(raw).not.toHaveProperty('secondaries')
+    expect(musclesOf(raw)).toEqual({ chest: 1, deltoids: 0.4, triceps: 0.4 })
+    expect(musclesOf(EXIDX['0577'])).toEqual({ chest: 1, deltoids: 0.4, triceps: 0.4, biceps: 0.4 })
+  })
+
+  it('gives an explicit custom collision precedence and restores the machine overlay', () => {
+    registerCustom([{
+      id: '0577', n: 'Owner machine press correction', bp: 'chest',
+      primaries: ['triceps'], secondaries: []
+    }])
+    expect(EXIDX['0577']).toMatchObject({ primaries: ['triceps'], secondaries: [] })
+    expect(musclesOf(EXIDX['0577'])).toEqual({ triceps: 1 })
+    registerCustom([])
+    expect(EXIDX['0577']).toMatchObject(MACHINE_BATCH_2['0577'])
+    expect(musclesOf(EXIDX['0577'])).toEqual({ chest: 1, deltoids: 0.4, triceps: 0.4, biceps: 0.4 })
+  })
+})

--- a/frontend/src/lib/exercises.js
+++ b/frontend/src/lib/exercises.js
@@ -1,7 +1,28 @@
 import { EXDB } from './exercises-data.js'
+import { USER_EXERCISE_MUSCLE_OVERRIDES, exerciseMuscleMetadataFor } from './exercise-muscle-batch-1.js'
 import { t } from './i18n-core.js'
 
 export { EXDB }
+
+// The generated dataset remains the compatibility/raw export. The runtime catalogue applies
+// owner-approved muscle metadata as a narrow overlay, so imports and historical tests that rely
+// on the upstream shape keep working while EXIDX and pickers see the corrected model.
+const catalogueExercise = ex => {
+  const metadata = exerciseMuscleMetadataFor(ex?.id)
+  if (!Object.keys(metadata).length) return ex
+  const out = { ...ex, ...metadata }
+  const user = USER_EXERCISE_MUSCLE_OVERRIDES[ex?.id] || {}
+  // A future dataset row may carry explicit arrays of its own; preserve those over generated
+  // defaults unless the owner has deliberately supplied a correction for the same field.
+  for (const key of ['primaries', 'secondaries']) {
+    if (Object.prototype.hasOwnProperty.call(ex, key) && !Object.prototype.hasOwnProperty.call(user, key)) out[key] = ex[key]
+  }
+  if (Array.isArray(out.primaries)) out.primaries = [...out.primaries]
+  if (Array.isArray(out.secondaries)) out.secondaries = [...out.secondaries]
+  return out
+}
+
+export const CATALOGUE = EXDB.map(catalogueExercise)
 
 // The generated dataset already supplies secondary muscles for most exercises. Keep the
 // handful of conservative catalogue additions that are useful to the muscle map here so a
@@ -23,8 +44,8 @@ export const smOf = ex => {
 }
 
 export const EXIDX = {}
-EXDB.forEach(e => { EXIDX[e.id] = e })
-export const BODYPARTS = [...new Set(EXDB.map(e => e.bp))].sort()
+CATALOGUE.forEach(e => { EXIDX[e.id] = e })
+export const BODYPARTS = [...new Set(CATALOGUE.map(e => e.bp))].sort()
 
 // Equipment options present in a given list of exercises, most common first (issue #6).
 // Deriving them from the *already filtered* list keeps the chip row short and means
@@ -39,25 +60,78 @@ export function equipmentOf(list) {
 // merged into the id index here so every EXIDX[id] lookup keeps working unchanged.
 let customIds = []
 export function registerCustom(list) {
-  customIds.forEach(id => delete EXIDX[id])
+  customIds.forEach(id => {
+    delete EXIDX[id]
+    const builtIn = CATALOGUE.find(ex => ex.id === id)
+    if (builtIn) EXIDX[id] = builtIn
+  })
   customIds = (list || []).map(e => e.id)
   ;(list || []).forEach(e => { EXIDX[e.id] = e })
 }
 // Full searchable catalogue — customs first so your own exercises are easy to find.
-export const allExercises = st => [...(st.customEx || []), ...EXDB]
+export const allExercises = st => [...(st.customEx || []), ...CATALOGUE]
+
+function searchableText(value) {
+  if (Array.isArray(value)) return value.map(searchableText).join(' ')
+  if (value == null) return ''
+  try { return String(value) } catch { return '' }
+}
+
+/** Case-insensitive search over built-in and legacy custom exercise metadata. */
+function isSubsequence(needle, hay) {
+  let i = 0
+  for (const ch of hay) {
+    if (ch === needle[i]) i++
+    if (i === needle.length) return true
+  }
+  return false
+}
+
+// Fuzzy match score for one exercise against a query. Best hits: exact field match, then
+// field prefix, then word-boundary starts, then substrings (closer to the start scores
+// better), and finally typo-tolerant ordered subsequences. Fields are weighted - the name
+// dominates, target/equipment matter, muscles and description are supporting evidence.
+// 0 means no match, so matchesExerciseSearch stays a boolean filter while the picker can
+// rank results by score.
+export function searchScore(exercise, query) {
+  const needle = searchableText(query).toLowerCase().trim()
+  if (!needle) return 1
+  const source = exercise && typeof exercise === 'object' ? exercise : {}
+  const fields = [['n', 100], ['tg', 40], ['eq', 40], ['sm', 30], ['muscleGroups', 30], ['primaries', 30], ['secondaries', 30], ['desc', 10]]
+  // Token-level matching: every query word must match somewhere (any order), so
+  // "press bench" finds "Bench Press". The score sums each token's best hit.
+  const tokens = needle.split(/[^a-z0-9]+/).filter(Boolean)
+  if (!tokens.length) return 0
+  let total = 0
+  for (const token of tokens) {
+    let best = 0
+    for (const [field, weight] of fields) {
+      const hay = searchableText(source[field]).toLowerCase()
+      if (!hay) continue
+      if (hay === token) best = Math.max(best, weight * 4)
+      else if (hay.startsWith(token)) best = Math.max(best, weight * 3)
+      const idx = hay.indexOf(token)
+      if (idx > 0) best = Math.max(best, weight * 2 - Math.min(idx, 20) * 0.5)
+      if (hay.split(/[^a-z0-9]+/).some(w => w.startsWith(token))) best = Math.max(best, weight * 2.5)
+      if (isSubsequence(token, hay)) best = Math.max(best, weight + Math.max(0, 10 - (hay.length - token.length)))
+    }
+    if (!best) return 0 // every token must match
+    total += best
+  }
+  return total
+}
+
+export function matchesExerciseSearch(exercise, query) {
+  return searchScore(exercise, query) > 0
+}
 
 // Media normally sits next to the app (img/ and gif/, mounted into the web container).
 // A build can point them somewhere else — the demo build pulls them off a CDN instead of
 // shipping ~140 MB of images into the deployment. `import.meta.env` is undefined in plain
 // Node; the guard keeps this module loadable without Vite.
-// The defaults are absolute on purpose (issue #79). A bare 'img/' resolves against the
-// current document's directory, so on the one two-segment route in the app, /plan/r/:id,
-// every request went to /plan/r/img/… and 404'd — and nginx's extension block has no
-// try_files, so it 404s rather than falling through to index.html, leaving a blank image
-// and nothing in the console.
 const ENV = import.meta.env || {}
-const IMG_BASE = ENV.VITE_IMG_BASE || '/img/'
-const GIF_BASE = ENV.VITE_GIF_BASE || '/gif/'
+const IMG_BASE = ENV.VITE_IMG_BASE || 'img/'
+const GIF_BASE = ENV.VITE_GIF_BASE || 'gif/'
 export const imgSrc = ex => IMG_BASE + ex.img
 export const gifSrc = ex => GIF_BASE + ex.gif
 

--- a/frontend/src/lib/muscles.js
+++ b/frontend/src/lib/muscles.js
@@ -7,10 +7,13 @@
 // map can actually draw, via ALIAS below. Anything genuinely undrawable (hands,
 // ankles, "cardiovascular system") maps to null and is dropped rather than guessed at.
 
-import { EXIDX , smOf } from './exercises.js'
+import { EXIDX, smOf } from './exercises.js'
 
 // The muscles a map can shade, in head-to-toe order — also the order of any list
 // built from them, so "what am I neglecting" reads top-down like a body.
+/** Completed-work boundary shared with the session runtime: warm-up rows never count. */
+const isWarmupRow = set => !!(set && (set.phase === 'warmup' || set.warmup === true))
+
 export const MUSCLES = [
   'trapezius', 'deltoids', 'chest', 'upper-back', 'serratus',
   'biceps', 'triceps', 'forearm',
@@ -64,23 +67,148 @@ const BY_BODYPART = {
   'upper legs': { quadriceps: 0.4, hamstring: 0.35, gluteal: 0.25 },
   'lower legs': { calves: 0.8, tibialis: 0.2 },
   neck: { trapezius: 1 },
+  'full body': { chest: 0.2, 'upper-back': 0.2, gluteal: 0.2, quadriceps: 0.2, hamstring: 0.1, abs: 0.1 },
   cardio: {},
 }
 
 const SECONDARY = 0.4   // a supporting muscle counts this much against a primary
 
-/** Muscles one exercise trains: { slug: 0…1 }. */
+const arrayOf = value => Array.isArray(value) ? value : value == null || value === '' ? [] : [value]
+
+function firstPresent(object, keys) {
+  if (!object || typeof object !== 'object') return null
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) return object[key]
+  }
+  return null
+}
+
+function explicitPartsOf(ex) {
+  if (!ex || typeof ex !== 'object') return null
+  const primary = firstPresent(ex, ['primaries', 'primaryMuscles', 'primary'])
+  const secondary = firstPresent(ex, ['secondaries', 'secondaryMuscles', 'secondary'])
+  if (primary !== null || secondary !== null) return {
+    primary: arrayOf(primary), secondary: arrayOf(secondary)
+  }
+  return null
+}
+
+function explicitGroupsOf(ex) {
+  if (!ex || typeof ex !== 'object') return null
+  if (Object.prototype.hasOwnProperty.call(ex, 'muscleGroups')) {
+    const groups = arrayOf(ex.muscleGroups)
+    return groups.length ? groups : null
+  }
+  if (Object.prototype.hasOwnProperty.call(ex, 'muscles')) {
+    const groups = arrayOf(ex.muscles)
+    return groups.length ? groups : null
+  }
+  if (Object.prototype.hasOwnProperty.call(ex, 'targetMuscles')) {
+    const groups = arrayOf(ex.targetMuscles)
+    return groups.length ? groups : null
+  }
+  return null
+}
+
+/** True only when the catalogue explicitly supplied muscle groups, not a body-part fallback. */
+export function hasExplicitMuscleMetadata(ex) {
+  if (!ex || typeof ex !== 'object') return false
+  const parts = explicitPartsOf(ex)
+  if (parts && [...parts.primary, ...parts.secondary].some(value => canonicalMuscle(value))) return true
+  const groups = explicitGroupsOf(ex)
+  if (groups && groups.some(value => canonicalMuscle(value))) return true
+  return [ex.tg, ex.mg, ...arrayOf(smOf(ex))].some(value => canonicalMuscle(value))
+}
+
+function canonicalMuscle(value) {
+  const name = String(value || '').toLowerCase().trim()
+  if (MUSCLES.includes(name)) return name
+  return ALIAS[name] || null
+}
+
+function canonicalUnique(values) {
+  const out = []
+  for (const value of values || []) {
+    const slug = canonicalMuscle(value)
+    if (slug && !out.includes(slug)) out.push(slug)
+  }
+  return out
+}
+
+/** Canonical unique muscle groups, accepting new primary/secondary arrays and legacy fields. */
+export function muscleGroupsOf(ex) {
+  const parts = explicitPartsOf(ex)
+  const explicit = explicitGroupsOf(ex)
+  const useParts = parts && [...parts.primary, ...parts.secondary].some(value => canonicalMuscle(value))
+  const source = useParts
+    ? [...parts.primary, ...parts.secondary]
+    : explicit || [ex?.tg, ex?.mg, ...arrayOf(smOf(ex))]
+  const out = canonicalUnique(source)
+  if (!out.length && !useParts && explicit == null) {
+    canonicalUnique(Object.keys(BY_BODYPART[ex?.bp] || {})).forEach(slug => out.push(slug))
+  }
+  return out
+}
+
+export const normalizeMuscleGroups = muscleGroupsOf
+
+/** True when any requested group matches; an empty request is an intentionally unfiltered query. */
+export function matchesMuscleGroups(ex, requested) {
+  const wanted = arrayOf(requested).map(canonicalMuscle).filter(Boolean)
+  if (!wanted.length) return true
+  const groups = new Set(muscleGroupsOf(ex))
+  return wanted.some(group => groups.has(group))
+}
+
+/** Muscles one exercise trains: { slug: 0…1 }. Duplicate metadata never adds load twice. */
 export function musclesOf(ex) {
   if (!ex) return {}
+  if (ex.muscleWeights && typeof ex.muscleWeights === 'object' && !Array.isArray(ex.muscleWeights)) {
+    const snapshot = {}
+    MUSCLES.forEach(slug => {
+      const weight = Number(ex.muscleWeights[slug])
+      if (Number.isFinite(weight) && weight > 0) snapshot[slug] = weight
+    })
+    if (Object.keys(snapshot).length) return snapshot
+  }
   const out = {}
   const add = (name, w) => {
-    const slug = ALIAS[String(name || '').toLowerCase().trim()]
+    const slug = canonicalMuscle(name)
     if (slug) out[slug] = Math.max(out[slug] || 0, w)
   }
-  add(ex.tg, 1)
-  ;smOf(ex).forEach(m => add(m, SECONDARY))
+  const parts = explicitPartsOf(ex)
+  const explicit = explicitGroupsOf(ex)
+  const useParts = parts && [...parts.primary, ...parts.secondary].some(value => canonicalMuscle(value))
+  if (useParts) {
+    parts.primary.forEach(m => add(m, 1))
+    parts.secondary.forEach(m => add(m, SECONDARY))
+  } else if (explicit) explicit.forEach(m => add(m, 1))
+  else {
+    add(ex.tg, 1)
+    add(ex.mg, SECONDARY)
+    arrayOf(smOf(ex)).forEach(m => add(m, SECONDARY))
+  }
   // Nothing recognised (custom exercises, or a target we don't draw) — use the body part.
   if (!Object.keys(out).length) Object.assign(out, BY_BODYPART[ex.bp] || {})
+  return out
+}
+
+/** Snapshot display and weighted muscle metadata into a completed history entry. */
+export function exerciseMuscleSnapshot(ex) {
+  if (!ex || typeof ex !== 'object') return {}
+  const out = {}
+  if (ex.n != null) out.n = ex.n
+  if (ex.bp != null) out.bp = ex.bp
+  const weights = musclesOf(ex)
+  if (Object.keys(weights).length) out.muscleWeights = { ...weights }
+  const parts = explicitPartsOf(ex)
+  if (parts) {
+    const primaries = canonicalUnique(parts.primary)
+    const secondaries = canonicalUnique(parts.secondary).filter(slug => !primaries.includes(slug))
+    if (primaries.length) out.primaries = primaries
+    if (secondaries.length) out.secondaries = secondaries
+  }
+  if (hasExplicitMuscleMetadata(ex)) out.muscleGroups = [...muscleGroupsOf(ex)]
   return out
 }
 
@@ -92,9 +220,12 @@ export function musclesOf(ex) {
  */
 export function loadOf(items) {
   const load = {}
-  items.forEach(({ id, sets }) => {
+  items.forEach(item => {
+    const { id, sets } = item || {}
     if (!sets) return
-    const m = musclesOf(EXIDX[id])
+    const historical = item.ex || item.exercise
+    const source = historical?.muscleWeights ? historical : (EXIDX[id] || historical || item)
+    const m = musclesOf(source)
     for (const slug in m) load[slug] = (load[slug] || 0) + m[slug] * sets
   })
   return load
@@ -108,15 +239,15 @@ export function loadOf(items) {
  */
 export const loadOfWorkouts = (workouts, pick) =>
   loadOf((workouts || []).flatMap(w =>
-    (w.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && !s.warmup && (!pick || pick(s))).length }))))
+    (w.entries || []).map(e => ({ id: e.id, ex: e.exercise || e, sets: (e.sets || []).filter(s => s.done && !isWarmupRow(s) && (!pick || pick(s))).length }))))
 
 /** Load a routine *would* produce, from its planned set counts. */
 export const loadOfRoutine = routine =>
-  loadOf((routine?.ex || []).map(c => ({ id: c.id, sets: c.sets || 1 })))
+  loadOf((routine?.ex || []).map(c => ({ id: c.id, ex: c, sets: c.sets || 1 })))
 
 /** Load for a workout still in progress — the sets ticked so far. */
 export const loadOfActive = active =>
-  loadOf((active?.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && !s.warmup).length })))
+  loadOf((active?.entries || []).map(e => ({ id: e.id, ex: e.exercise || e, sets: (e.sets || []).filter(s => s.done && !isWarmupRow(s)).length })))
 
 /**
  * Shade buckets 0–4 per muscle.

--- a/frontend/src/lib/muscles.test.js
+++ b/frontend/src/lib/muscles.test.js
@@ -1,9 +1,45 @@
-import { describe, expect, it } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { EXIDX, EXDB, smOf } from './exercises.js'
-import { musclesOf } from './muscles.js'
+import { MUSCLE_NAME, exerciseMuscleSnapshot, loadOf, loadOfWorkouts, matchesMuscleGroups, muscleGroupsOf, musclesOf } from './muscles.js'
 
-// The catalogue keeps the source dataset's secondary-muscle spellings; musclesOf maps
-// those aliases to the canonical body-map slugs and applies the 0.4 support weight.
+describe('multi-muscle exercise metadata', () => {
+  it('normalizes legacy primary/secondary fields and removes duplicate groups', () => {
+    const ex = { tg: 'pectorals', mg: 'triceps', sm: ['triceps', 'chest'] }
+    expect(muscleGroupsOf(ex)).toEqual(['chest', 'triceps'])
+    expect(musclesOf(ex)).toEqual({ chest: 1, triceps: 0.4 })
+  })
+
+  it('uses explicit multi-group metadata when present and supports legacy single groups', () => {
+    expect(muscleGroupsOf({ muscleGroups: ['chest', 'pectorals', 'triceps'] })).toEqual(['chest', 'triceps'])
+    expect(muscleGroupsOf({ tg: 'chest' })).toEqual(['chest'])
+    expect(MUSCLE_NAME.chest).toBe('Chest')
+  })
+
+  it('falls back to the legacy body-part map when an optional multi-group field is empty', () => {
+    expect(muscleGroupsOf({ bp: 'back', muscleGroups: [] })).toEqual(['upper-back', 'lower-back'])
+    expect(matchesMuscleGroups({ bp: 'back', muscleGroups: [] }, ['lower-back'])).toBe(true)
+  })
+
+  it('matches an exercise when any requested muscle group matches', () => {
+    const ex = { muscleGroups: ['chest', 'triceps'] }
+    expect(matchesMuscleGroups(ex, ['hamstring', 'triceps'])).toBe(true)
+    expect(matchesMuscleGroups(ex, ['hamstring', 'gluteal'])).toBe(false)
+    expect(matchesMuscleGroups(ex, [])).toBe(true)
+  })
+
+  it('counts one effective set per unique group instead of double counting duplicates', () => {
+    expect(loadOf([{ id: 'inline', ex: { tg: 'chest', sm: ['chest', 'triceps'] }, sets: 2 }]))
+      .toEqual({ chest: 2, triceps: 0.8 })
+  })
+
+  it('uses multi-muscle metadata carried by a history entry when its catalogue id is unavailable', () => {
+    expect(loadOfWorkouts([{ entries: [{
+      id: 'deleted-custom', muscleGroups: ['chest', 'chest', 'triceps'],
+      sets: [{ done: true }]
+    }] }])).toEqual({ chest: 1, triceps: 1 })
+  })
+})
+
 describe('catalogue secondary muscles', () => {
   it('maps a bench press to chest, triceps and deltoids', () => {
     expect(musclesOf(EXIDX['0025'])).toMatchObject({
@@ -16,7 +52,7 @@ describe('catalogue secondary muscles', () => {
   it('maps a squat to glutes, quads and hamstrings', () => {
     expect(musclesOf(EXIDX['0043'])).toMatchObject({
       gluteal: 1,
-      quadriceps: 0.4,
+      quadriceps: 1,
       hamstring: 0.4,
     })
   })
@@ -40,5 +76,63 @@ describe('catalogue secondary additions', () => {
     expect(smOf(raw)).toContain('rear deltoids')
     // the alias collapses onto the deltoids slug in the canonical muscle map
     expect(musclesOf(raw)).toHaveProperty('deltoids')
+  })
+})
+
+
+describe('explicit multi-primary metadata', () => {
+  it('gives every primary full weight and secondaries supporting weight', () => {
+    const ex = {
+      bp: 'chest', tg: 'abs', mg: 'triceps', sm: ['lower back'],
+      primaries: ['chest', 'triceps', 'chest'], secondaries: ['deltoids', 'triceps']
+    }
+    expect(muscleGroupsOf(ex)).toEqual(['chest', 'triceps', 'deltoids'])
+    expect(musclesOf(ex)).toEqual({ chest: 1, triceps: 1, deltoids: 0.4 })
+  })
+
+  it('keeps the body-part fallback when primaries are absent or explicitly empty', () => {
+    const expected = { 'upper-back': 0.75, 'lower-back': 0.25 }
+    expect(musclesOf({ bp: 'back' })).toEqual(expected)
+    expect(musclesOf({ bp: 'back', primaries: [] })).toEqual(expected)
+  })
+
+  it('keeps legacy metadata when a new array field is present but empty', () => {
+    expect(exerciseMuscleSnapshot({ bp: 'chest', tg: 'abs', primaries: [] })).toMatchObject({
+      muscleGroups: ['abs']
+    })
+  })
+
+  it('provides a conservative Full body fallback for legacy custom exercises', () => {
+    expect(muscleGroupsOf({ bp: 'full body' })).toEqual(['chest', 'upper-back', 'gluteal', 'quadriceps', 'hamstring', 'abs'])
+    expect(musclesOf({ bp: 'full body' })).toEqual({
+      chest: 0.2, 'upper-back': 0.2, gluteal: 0.2, quadriceps: 0.2, hamstring: 0.1, abs: 0.1
+    })
+  })
+
+  it('preserves explicit primary and secondary arrays in history snapshots', () => {
+    expect(exerciseMuscleSnapshot({
+      n: 'Deadlift', bp: 'full body', primaries: ['gluteal', 'lower-back'], secondaries: ['hamstring']
+    })).toMatchObject({
+      n: 'Deadlift', bp: 'full body', primaries: ['gluteal', 'lower-back'], secondaries: ['hamstring'],
+      muscleGroups: ['gluteal', 'lower-back', 'hamstring']
+    })
+  })
+})
+
+
+describe('map load with warm-up phases', () => {
+  it('excludes warm-up sets from the by-sets-worked map', () => {
+    const w = {
+      id: 'w1', d: '2026-08-01', start: Date.UTC(2026, 7, 1, 10), unit: 'kg',
+      entries: [{
+        id: '0025',
+        sets: [
+          { done: true, phase: 'warmup', w: 20, r: 8 },
+          { done: true, phase: 'work', w: 60, r: 8 },
+        ],
+      }],
+    }
+    const load = loadOfWorkouts([w], null)
+    expect(load.chest).toBe(1)
   })
 })

--- a/frontend/src/lib/programmes.js
+++ b/frontend/src/lib/programmes.js
@@ -1,0 +1,994 @@
+import { muscleGroupsOf, musclesOf } from './muscles.js'
+
+// Programme scheduling is calendar- and history-derived. Keep the clock at the boundary so
+// tests, imports, and callers rendering more than one surface can use one snapshot of `now`.
+export const HOUR = 60 * 60 * 1000
+export const DAY = 24 * HOUR
+export const RECOVERY_HOURS = 48
+export const RECOVERY_WINDOW = RECOVERY_HOURS * HOUR
+export const PROGRAMME_INSTANCE_VERSION = 1
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+const WEEKDAY_NAMES = {
+  mon: 1, monday: 1,
+  tue: 2, tues: 2, tuesday: 2,
+  wed: 3, wednesday: 3,
+  thu: 4, thur: 4, thurs: 4, thursday: 4,
+  fri: 5, friday: 5,
+  sat: 6, saturday: 6,
+  sun: 7, sunday: 7
+}
+
+const finite = value => Number.isFinite(Number(value))
+const numberOr = (value, fallback) => finite(value) ? Number(value) : fallback
+
+function clone(value) {
+  if (Array.isArray(value)) return value.map(clone)
+  if (!value || typeof value !== 'object') return value
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, clone(item)]))
+}
+
+function millis(value) {
+  if (value instanceof Date) return value.getTime()
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return NaN
+}
+
+function validTimeZone(value) {
+  if (typeof value !== 'string' || !value.trim()) return null
+  try {
+    return new Intl.DateTimeFormat('en-US', { timeZone: value }).resolvedOptions().timeZone
+  } catch {
+    return null
+  }
+}
+
+function deviceTimeZone() {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+}
+
+function timeZoneOrLocal(value) {
+  return validTimeZone(value) || validTimeZone(deviceTimeZone()) || 'UTC'
+}
+
+function partsAt(value, timeZone) {
+  const at = millis(value)
+  if (!Number.isFinite(at)) return null
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: timeZoneOrLocal(timeZone),
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+    weekday: 'short', hourCycle: 'h23'
+  })
+  const parts = Object.fromEntries(formatter.formatToParts(new Date(at))
+    .filter(part => part.type !== 'literal')
+    .map(part => [part.type, part.value]))
+  // A few ICU versions render midnight as 24 even with h23. Date.UTC needs 0–23.
+  const hour = parts.hour === '24' ? 0 : Number(parts.hour)
+  return {
+    year: Number(parts.year), month: Number(parts.month), day: Number(parts.day),
+    hour, minute: Number(parts.minute), second: Number(parts.second),
+    weekday: WEEKDAY_NAMES[String(parts.weekday || '').toLowerCase()] || 1
+  }
+}
+
+function isoFromParts(parts) {
+  if (!parts || !finite(parts.year) || !finite(parts.month) || !finite(parts.day)) return null
+  return `${String(parts.year).padStart(4, '0')}-${String(parts.month).padStart(2, '0')}-${String(parts.day).padStart(2, '0')}`
+}
+
+function validISODate(value) {
+  if (typeof value !== 'string' || !ISO_DATE.test(value)) return null
+  const parsed = Date.UTC(Number(value.slice(0, 4)), Number(value.slice(5, 7)) - 1, Number(value.slice(8, 10)))
+  return Number.isFinite(parsed) && new Date(parsed).toISOString().slice(0, 10) === value ? value : null
+}
+
+function isoAt(value, timeZone) {
+  const existing = validISODate(value)
+  return existing || isoFromParts(partsAt(value, timeZone))
+}
+
+function dateDays(value) {
+  const date = validISODate(value)
+  return date == null ? NaN : Date.UTC(Number(date.slice(0, 4)), Number(date.slice(5, 7)) - 1, Number(date.slice(8, 10))) / DAY
+}
+
+function isoFromDays(days) {
+  if (!Number.isFinite(days)) return null
+  return new Date(days * DAY).toISOString().slice(0, 10)
+}
+
+function addDays(value, amount) {
+  const days = dateDays(value)
+  return isoFromDays(days + Number(amount || 0))
+}
+
+function compareDates(a, b) {
+  const left = validISODate(a) || '9999-12-31'
+  const right = validISODate(b) || '9999-12-31'
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function maxDate(a, b) {
+  return compareDates(a, b) >= 0 ? a : b
+}
+
+function weekdayOf(value) {
+  const days = dateDays(value)
+  if (!Number.isFinite(days)) return null
+  return ((new Date(days * DAY).getUTCDay() + 6) % 7) + 1
+}
+
+/**
+ * The date/weekday anchor for a new cycle. Week 1 is the current Monday only when today
+ * is Monday; any other start date anchors to the following Monday. Calendar arithmetic is
+ * performed on plain ISO dates, not local midnight, so DST never changes a week boundary.
+ */
+export function week1StartDate({ now = Date.now(), timeZone } = {}) {
+  const zone = timeZoneOrLocal(timeZone)
+  const today = isoAt(now, zone)
+  if (!today) return null
+  const weekday = weekdayOf(today)
+  return addDays(today, weekday === 1 ? 0 : 8 - weekday)
+}
+
+/** Return the device-local IANA zone, offset at this instant, and calendar date. */
+export function scheduleWriteContext(value = {}, explicitTimeZone) {
+  let now = value
+  let timeZone = explicitTimeZone
+  if (value && typeof value === 'object' && !(value instanceof Date)) {
+    now = value.now == null ? Date.now() : value.now
+    timeZone = value.timeZone ?? value.timezone ?? explicitTimeZone
+  }
+  const zone = timeZoneOrLocal(timeZone)
+  const at = millis(now)
+  const parts = partsAt(at, zone)
+  const wallClockUTC = parts
+    ? Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second)
+    : NaN
+  const offsetMinutes = Number.isFinite(wallClockUTC) && Number.isFinite(at)
+    ? Math.round((wallClockUTC - Math.trunc(at / 1000) * 1000) / 60000)
+    : null
+  return {
+    timeZone: zone,
+    offsetMinutes,
+    calendarDate: isoFromParts(parts),
+    recordedAt: Number.isFinite(at) ? new Date(at).toISOString() : null
+  }
+}
+
+/** Return a compact marker suitable for both active state and completed/partial history. */
+export function programmeInstanceMarker(value) {
+  if (!value || typeof value !== 'object') return null
+  const nested = value.programmeInstance && typeof value.programmeInstance === 'object'
+    ? value.programmeInstance
+    : value
+  const instanceId = nested.instanceId ?? value.instanceId
+  if (typeof instanceId !== 'string' || !instanceId.trim()) return null
+  const marker = { version: PROGRAMME_INSTANCE_VERSION, instanceId }
+  const fields = [
+    'programmeId', 'cycleId', 'sessionTemplateId', 'weekIndex', 'weekday', 'ordinal',
+    'nominalDate', 'locationId'
+  ]
+  for (const field of fields) {
+    const source = nested[field] ?? value[field] ?? (field === 'sessionTemplateId' ? nested.sessionId ?? value.sessionId : undefined)
+    if (source !== undefined && source !== null && source !== '') marker[field] = clone(source)
+  }
+  return marker
+}
+
+function cycleStatus(cycle) {
+  return String(cycle?.status || '').toLowerCase()
+}
+
+function cycleCreatedAt(cycle) {
+  const value = millis(cycle?.createdAt ?? cycle?.startedAt ?? cycle?.id)
+  return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER
+}
+
+function cycleComparator(a, b) {
+  const date = cycleCreatedAt(a.cycle || a) - cycleCreatedAt(b.cycle || b)
+  if (date) return date
+  const aId = String((a.cycle || a).id || '')
+  const bId = String((b.cycle || b).id || '')
+  return aId.localeCompare(bId)
+}
+
+function weekNumber(week, index) {
+  return numberOr(week?.weekIndex ?? week?.index, index + 1)
+}
+
+function normalizeWeekday(value, fallback) {
+  if (typeof value === 'string') {
+    const numeric = Number(value)
+    if (Number.isInteger(numeric)) value = numeric
+    else value = WEEKDAY_NAMES[value.trim().toLowerCase()]
+  }
+  if (value === 0) return 7
+  return Number.isInteger(Number(value)) && Number(value) >= 1 && Number(value) <= 7
+    ? Number(value)
+    : fallback
+}
+
+function dayEntries(week) {
+  const days = week?.days
+  if (Array.isArray(days)) return days.map((day, index) => [day, normalizeWeekday(day?.weekday, index + 1)])
+  if (!days || typeof days !== 'object') return []
+  return Object.entries(days).map(([key, day], index) => [day, normalizeWeekday(day?.weekday ?? key, index + 1)])
+}
+
+function sessionEntries(day) {
+  if (!day || typeof day !== 'object' || day.mode === 'rest' || day.rest === true) return []
+  if (!Array.isArray(day.sessions)) return []
+  return day.sessions
+}
+
+function snapshotWeeks(cycle) {
+  const snapshot = cycle?.snapshot
+  if (Array.isArray(snapshot)) return snapshot
+  if (Array.isArray(snapshot?.weeks)) return snapshot.weeks
+  if (Array.isArray(cycle?.weeks)) return cycle.weeks
+  return []
+}
+
+function routineSnapshotOf(session) {
+  return session?.routineSnapshot || session?.routine || session?.snapshot || null
+}
+
+function generatedTemplateCounts(cycle) {
+  const counts = new Map()
+  for (const week of snapshotWeeks(cycle)) {
+    for (const [day] of dayEntries(week)) {
+      for (const session of sessionEntries(day)) {
+        const templateId = session?.sessionTemplateId ?? session?.templateId ?? session?.id
+        if (typeof templateId !== 'string' || !templateId || typeof session?.instanceId === 'string') continue
+        counts.set(templateId, (counts.get(templateId) || 0) + 1)
+      }
+    }
+  }
+  return counts
+}
+
+function cycleAnchor(cycle, now, timeZone) {
+  const stored = validISODate(cycle?.week1StartDate)
+  if (stored) return stored
+  const zone = cycle?.timeZone || timeZone
+  return week1StartDate({ now: cycle?.startedAt ?? now, timeZone: zone })
+}
+
+function materializeCycleInstancesWithDiagnostics(cycle, options = {}) {
+  const diagnostics = []
+  if (!cycle || typeof cycle !== 'object' || typeof cycle.id !== 'string' || !cycle.id) {
+    return { items: [], diagnostics: [{ reason: 'invalid-cycle', cycleId: cycle?.id ?? null }] }
+  }
+  const anchor = cycleAnchor(cycle, options.now ?? Date.now(), options.timeZone)
+  if (!anchor) return { items: [], diagnostics: [{ reason: 'missing-calendar-anchor', cycleId: cycle.id }] }
+  const items = []
+  const ordinals = new Map()
+  const generatedCounts = generatedTemplateCounts(cycle)
+  snapshotWeeks(cycle).forEach((week, weekIndex) => {
+    const index = weekNumber(week, weekIndex)
+    for (const [day, weekday] of dayEntries(week)) {
+      if (String(week?.mode || '').toLowerCase() === 'rest' || day?.rest === true || day?.mode === 'rest') continue
+      const ordinalKey = `${index}:${weekday}`
+      const priorSessions = ordinals.get(ordinalKey) || 0
+      sessionEntries(day).forEach((session, sessionIndex) => {
+        const sessionTemplateId = session?.sessionTemplateId ?? session?.templateId ?? session?.id
+        if (typeof sessionTemplateId !== 'string' || !sessionTemplateId) {
+          diagnostics.push({ reason: 'missing-session-template-id', cycleId: cycle.id, weekIndex: index, weekday })
+          return
+        }
+        const routineSnapshot = routineSnapshotOf(session)
+        const routineId = session.routineId ?? routineSnapshot?.id ?? sessionTemplateId
+        const ordinal = numberOr(session.ordinal, priorSessions + sessionIndex + 1)
+        const explicitInstanceId = typeof session.instanceId === 'string' && session.instanceId
+          ? session.instanceId
+          : null
+        const instanceId = explicitInstanceId || (generatedCounts.get(sessionTemplateId) > 1
+          ? `pi:${cycle.id}:w${index}:d${weekday}:o${ordinal}:${sessionTemplateId}`
+          : `pi:${cycle.id}:${sessionTemplateId}`)
+        const nominalDate = addDays(anchor, (index - 1) * 7 + weekday - 1)
+        items.push({
+          instanceId,
+          source: 'programme',
+          routineId,
+          routineSnapshot: clone(routineSnapshot),
+          programmeId: cycle.programmeId ?? null,
+          cycleId: cycle.id,
+          sessionTemplateId,
+          weekIndex: index,
+          weekday,
+          ordinal,
+          nominalDate,
+          projectedDate: nominalDate,
+          locationId: session.locationId ?? null,
+          cycleCreatedAt: cycleCreatedAt(cycle),
+          cycleTimeZone: cycle.timeZone ?? options.timeZone ?? null,
+          status: 'pending',
+          partial: false,
+          owed: false,
+          miss: false,
+          blocked: false,
+          _sourceOrder: items.length,
+          _session: clone(session)
+        })
+      })
+      ordinals.set(ordinalKey, priorSessions + sessionEntries(day).length)
+    }
+  })
+  return { items, diagnostics }
+}
+
+/** Materialize immutable per-cycle instances; no derived dates are written back to the cycle. */
+export function materializeCycleInstances(cycle, options = {}) {
+  return materializeCycleInstancesWithDiagnostics(cycle, options).items
+}
+
+function recordTime(record) {
+  for (const field of ['end', 'start', 'completedAt', 'recordedAt', 'updatedAt']) {
+    const value = millis(record?.[field])
+    if (Number.isFinite(value)) return value
+  }
+  return NaN
+}
+
+function explicitCompletionRatio(record) {
+  const completion = record?.completion
+  if (!completion || !finite(completion.completedWorkSets) || !finite(completion.prescribedWorkSets)) return null
+  const prescribed = Number(completion.prescribedWorkSets)
+  if (prescribed <= 0) return null
+  return Number(completion.completedWorkSets) / prescribed
+}
+
+function classifyRecord(record) {
+  if (!record || typeof record !== 'object') return { status: 'pending', partial: false, owed: false, rank: 0 }
+  const partial = record.partial === true
+  const explicitOwed = typeof record.owed === 'boolean' ? record.owed : null
+  const schedule = typeof record.schedule === 'string' ? record.schedule.toLowerCase() : null
+  const ratio = explicitCompletionRatio(record)
+  const thresholdMet = record.completion && typeof record.completion.thresholdMet === 'boolean'
+    ? record.completion.thresholdMet
+    : ratio == null ? null : ratio >= 0.3
+
+  const explicitExit = String(record.exitIntent ?? record.completion?.exitIntent ?? record.completion?.disposition ?? '').toLowerCase()
+  const overrideOwed = explicitExit === 'continue' ? true : explicitExit === 'skip' ? false : null
+
+  if (!partial) {
+    if (record.owed === true || schedule === 'repeat' || record.complete === false) {
+      return { status: 'invalid', partial: false, owed: false, rank: 1, reason: 'contradictory-completion' }
+    }
+    return { status: 'completed', partial: false, owed: false, rank: 4 }
+  }
+  if (record.complete === true) {
+    return { status: 'invalid', partial: true, owed: false, rank: 1, reason: 'contradictory-partial' }
+  }
+  const scheduleOwed = schedule === 'repeat' ? true : schedule === 'advance' ? false : null
+  if (overrideOwed != null) {
+    if ((explicitOwed != null && explicitOwed !== overrideOwed) ||
+        (scheduleOwed != null && scheduleOwed !== overrideOwed)) {
+      return { status: 'invalid', partial: true, owed: false, rank: 1, reason: 'contradictory-exit-intent' }
+    }
+    return overrideOwed
+      ? { status: 'owed', partial: true, owed: true, rank: 3 }
+      : { status: 'partial-advanced', partial: true, owed: false, rank: 2 }
+  }
+  if ((explicitOwed === true && schedule === 'advance') ||
+      (explicitOwed === false && schedule === 'repeat')) {
+    return { status: 'invalid', partial: true, owed: false, rank: 1, reason: 'contradictory-partial' }
+  }
+  const thresholdOwed = thresholdMet == null ? null : !thresholdMet
+  if ((explicitOwed != null && thresholdOwed != null && explicitOwed !== thresholdOwed) ||
+      (scheduleOwed != null && thresholdOwed != null && scheduleOwed !== thresholdOwed)) {
+    return { status: 'invalid', partial: true, owed: false, rank: 1, reason: 'contradictory-threshold' }
+  }
+
+  const owed = explicitOwed ?? scheduleOwed ?? (thresholdOwed == null ? null : thresholdOwed)
+  if (owed === true) return { status: 'owed', partial: true, owed: true, rank: 3 }
+  if (owed === false) return { status: 'partial-advanced', partial: true, owed: false, rank: 2 }
+  return { status: 'invalid', partial: true, owed: false, rank: 1, reason: 'unclassified-record' }
+}
+
+function recordMarkerId(record) {
+  return programmeInstanceMarker(record)?.instanceId || null
+}
+
+function stableText(value) {
+  if (Array.isArray(value)) return `[${value.map(stableText).join(',')}]`
+  if (!value || typeof value !== 'object') return JSON.stringify(value)
+  return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableText(value[key])}`).join(',')}}`
+}
+
+function recordsByInstance(workouts) {
+  const grouped = new Map()
+  ;(Array.isArray(workouts) ? workouts : []).forEach((record, index) => {
+    const instanceId = recordMarkerId(record)
+    if (!instanceId) return
+    const entry = { record, index, classification: classifyRecord(record), at: recordTime(record) }
+    const list = grouped.get(instanceId) || []
+    list.push(entry)
+    grouped.set(instanceId, list)
+  })
+  const latest = new Map()
+  for (const [instanceId, list] of grouped) {
+    list.sort((a, b) => {
+      const at = (Number.isFinite(a.at) ? a.at : -Infinity) - (Number.isFinite(b.at) ? b.at : -Infinity)
+      if (at) return at
+      const rank = a.classification.rank - b.classification.rank
+      if (rank) return rank
+      const text = stableText(a.record).localeCompare(stableText(b.record))
+      if (text) return text
+      return a.index - b.index
+    })
+    latest.set(instanceId, { ...list[list.length - 1], attemptCount: list.length })
+  }
+  return latest
+}
+
+function latestClassicRecord(item, workouts) {
+  if (!item || item.source !== 'classic' || !item.routineId) return null
+  const entries = []
+  for (const [index, record] of (Array.isArray(workouts) ? workouts : []).entries()) {
+    if (recordMarkerId(record)) continue
+    const routineId = record?.routineId ?? record?.routine?.id
+    if (routineId !== item.routineId) continue
+    const recordDate = validISODate(record?.d) || validISODate(record?.date) || validISODate(record?.calendarDate)
+    const timestampDate = recordDate || isoAt(record?.end ?? record?.start, 'UTC')
+    if (timestampDate !== item.nominalDate) continue
+    entries.push({ record, index, classification: classifyRecord(record), at: recordTime(record) })
+  }
+  if (!entries.length) return null
+  entries.sort((a, b) => {
+    const at = (Number.isFinite(a.at) ? a.at : -Infinity) - (Number.isFinite(b.at) ? b.at : -Infinity)
+    if (at) return at
+    const rank = a.classification.rank - b.classification.rank
+    if (rank) return rank
+    const text = stableText(a.record).localeCompare(stableText(b.record))
+    return text || a.index - b.index
+  })
+  return { ...entries[entries.length - 1], attemptCount: entries.length }
+}
+
+function latestForItem(item, latestRecords, workouts) {
+  const mapped = latestRecords.get(item.instanceId)
+  if (mapped) return mapped
+  if (item.source === 'classic') {
+    const rid = item._claimedRecord
+    if (!rid) return null
+    const list = Array.isArray(workouts) ? workouts : []
+    const index = list.findIndex(r => r?.id === rid)
+    if (index < 0) return null
+    const record = list[index]
+    return { record, index, classification: classifyRecord(record), at: recordTime(record), attemptCount: 1 }
+  }
+  return null
+}
+
+function explicitMuscleWeights(value) {
+  if (!value || typeof value !== 'object') return {}
+  const result = {}
+  const canonicalNames = names => muscleGroupsOf({ muscleGroups: names })
+  const add = (name, weight) => {
+    const amount = Number(weight)
+    if (!Number.isFinite(amount) || amount <= 0) return
+    for (const canonical of canonicalNames([name])) {
+      result[canonical] = Math.max(result[canonical] || 0, amount)
+    }
+  }
+  for (const key of ['muscleWeights', 'muscles']) {
+    const source = value[key]
+    if (source && typeof source === 'object' && !Array.isArray(source)) {
+      for (const [name, weight] of Object.entries(source)) add(name, weight)
+    }
+  }
+  for (const key of ['primaries', 'primaryMuscles', 'primary', 'muscleGroups', 'muscles']) {
+    const source = value[key]
+    if (Array.isArray(source)) canonicalNames(source).forEach(name => add(name, 1))
+  }
+  for (const key of ['secondaries', 'secondaryMuscles', 'secondary']) {
+    const source = value[key]
+    if (Array.isArray(source)) canonicalNames(source).forEach(name => add(name, 0.4))
+  }
+  return result
+}
+
+function mergeWeights(target, source) {
+  for (const [name, weight] of Object.entries(source || {})) {
+    if (Number(weight) > 0) target[name] = Math.max(target[name] || 0, Number(weight))
+  }
+  return target
+}
+
+function weightsForExercise(value) {
+  const explicit = explicitMuscleWeights(value)
+  if (Object.keys(explicit).length) return explicit
+  try {
+    return musclesOf(value || {})
+  } catch {
+    return {}
+  }
+}
+
+function weightsForSession(item) {
+  const target = {}
+  const session = item?._session || {}
+  mergeWeights(target, explicitMuscleWeights(session))
+  const routine = item?.routineSnapshot
+  for (const exercise of Array.isArray(routine?.ex) ? routine.ex : []) {
+    mergeWeights(target, weightsForExercise(exercise))
+  }
+  return target
+}
+
+function isWorkSet(set) {
+  return !!set && set.done === true && set.phase !== 'warmup' && set.phase !== 'warm-up' && set.warmup !== true
+}
+
+function workoutWeights(workout) {
+  const target = {}
+  mergeWeights(target, explicitMuscleWeights(workout))
+  for (const entry of Array.isArray(workout?.entries) ? workout.entries : []) {
+    const source = entry?.exercise || entry
+    if (!(Array.isArray(entry?.sets) && entry.sets.some(isWorkSet))) continue
+    mergeWeights(target, weightsForExercise(source))
+  }
+  return target
+}
+
+function hasCompletedWorkSet(workout) {
+  return Array.isArray(workout?.entries) && workout.entries.some(entry =>
+    Array.isArray(entry?.sets) && entry.sets.some(isWorkSet))
+}
+
+function overlaps(left, right) {
+  return Object.keys(left || {}).filter(name => Number(left[name]) > 0 && Number(right?.[name]) > 0)
+}
+
+function recoveryGuard(item, workouts, now) {
+  const target = weightsForSession(item)
+  if (!Object.keys(target).length) return null
+  const atNow = millis(now)
+  if (!Number.isFinite(atNow)) return { reason: 'invalid-clock', bypassed: false }
+  let latest = null
+  for (const workout of Array.isArray(workouts) ? workouts : []) {
+    const at = recordTime(workout)
+    if (!Number.isFinite(at) || at > atNow || !hasCompletedWorkSet(workout)) continue
+    const overlap = overlaps(target, workoutWeights(workout))
+    if (!overlap.length) continue
+    if (!latest || at > latest.at || (at === latest.at && stableText(workout) > stableText(latest.workout))) {
+      latest = { workout, at, overlap }
+    }
+  }
+  if (!latest) return null
+  const guardUntil = latest.at + RECOVERY_WINDOW
+  if (atNow < guardUntil) {
+    return {
+      reason: 'recovery-overlap',
+      bypassed: false,
+      lastCompletedAt: new Date(latest.at).toISOString(),
+      guardUntil: new Date(guardUntil).toISOString(),
+      overlapMuscles: [...latest.overlap]
+    }
+  }
+  return null
+}
+
+function isUnsettled(item) {
+  return item.status !== 'completed' && item.status !== 'partial-advanced' && item.status !== 'duplicate'
+}
+
+function itemComparator(a, b) {
+  const date = compareDates(a.projectedDate, b.projectedDate)
+  if (date) return date
+  if (String(a.cycleId || '') === String(b.cycleId || '')) {
+    const week = numberOr(a.weekIndex, 0) - numberOr(b.weekIndex, 0)
+    if (week) return week
+    const weekday = numberOr(a.weekday, 0) - numberOr(b.weekday, 0)
+    if (weekday) return weekday
+    const ordinal = numberOr(a.ordinal, 0) - numberOr(b.ordinal, 0)
+    if (ordinal) return ordinal
+  } else {
+    const cycle = (a.cycleCreatedAt ?? Number.MAX_SAFE_INTEGER) - (b.cycleCreatedAt ?? Number.MAX_SAFE_INTEGER)
+    if (cycle) return cycle
+    const cycleId = String(a.cycleId || '').localeCompare(String(b.cycleId || ''))
+    if (cycleId) return cycleId
+  }
+  const week = numberOr(a.weekIndex, 0) - numberOr(b.weekIndex, 0)
+  if (week) return week
+  const weekday = numberOr(a.weekday, 0) - numberOr(b.weekday, 0)
+  if (weekday) return weekday
+  const ordinal = numberOr(a.ordinal, 0) - numberOr(b.ordinal, 0)
+  if (ordinal) return ordinal
+  return String(a.instanceId || '').localeCompare(String(b.instanceId || ''))
+}
+
+function nominalComparator(a, b) {
+  const date = compareDates(a.nominalDate, b.nominalDate)
+  if (date) return date
+  return itemComparator(a, b)
+}
+
+function settleAndSlide(items, latestRecords, workouts, options) {
+  const now = options.now ?? Date.now()
+  const currentDate = isoAt(now, options.timeZone)
+  const ordered = [...items].sort(nominalComparator)
+  let previousUnsettled = null
+  for (const item of ordered) {
+    const latest = latestForItem(item, latestRecords, workouts)
+    const classification = latest?.classification || (item.status === 'completed'
+      ? { status: 'completed', partial: false, owed: false, rank: 4 }
+      : { status: 'pending', partial: false, owed: false, rank: 0 })
+    item.status = classification.status
+    item.partial = classification.partial
+    item.owed = classification.owed
+    item.miss = classification.status === 'owed'
+    item.blocked = classification.status === 'invalid'
+    item.blockedReason = classification.reason || null
+    item.sameInstance = !!latest
+    item.attemptCount = latest?.attemptCount || 0
+    item.recordId = latest?.record?.id || null
+    item.latestRecord = latest?.record ? clone(latest.record) : null
+
+    const unsettled = isUnsettled(item)
+    let projected = item.nominalDate
+    if (unsettled && compareDates(item.nominalDate, currentDate) <= 0) projected = maxDate(item.nominalDate, currentDate)
+    if (previousUnsettled && unsettled && item.nominalDate !== previousUnsettled.nominalDate) {
+      const previousShifted = previousUnsettled.projectedDate !== previousUnsettled.nominalDate ||
+        compareDates(previousUnsettled.nominalDate, currentDate) < 0 || previousUnsettled.status === 'owed' || previousUnsettled.status === 'invalid'
+      if (previousShifted && compareDates(projected, previousUnsettled.projectedDate) <= 0) {
+        projected = addDays(previousUnsettled.projectedDate, 1)
+      }
+    }
+    item.projectedDate = projected
+    item.guardUntil = null
+    if (unsettled) previousUnsettled = item
+  }
+
+  // Attach recovery data only to the current candidate. It is deliberately not used to
+  // reorder the queue: a guarded owed head is still the head and later work cannot bypass it.
+  const queue = ordered.filter(isUnsettled).sort((a, b) => {
+    const aFront = a.status === 'owed' || a.status === 'invalid' ? 0 : 1
+    const bFront = b.status === 'owed' || b.status === 'invalid' ? 0 : 1
+    return aFront - bFront || itemComparator(a, b)
+  })
+  const front = queue[0] || null
+  let blocked = null
+  let eligible = []
+  if (front) {
+    if (front.status === 'invalid') {
+      blocked = { reason: front.blockedReason || 'unclassified-record', bypassed: false }
+      front.blocked = true
+    } else if (compareDates(front.projectedDate, currentDate) > 0) {
+      blocked = null
+    } else {
+      const guard = recoveryGuard(front, workouts, now)
+      if (guard) {
+        blocked = guard
+        front.guardUntil = guard.guardUntil
+        front.blocked = true
+      } else {
+        eligible = [front]
+      }
+    }
+    for (const item of queue) {
+      if (item !== front) item.bypassed = true
+    }
+  }
+  const owed = queue.filter(item => item.status === 'owed')
+  return { ordered, queue, front, owed, eligible, blocked }
+}
+
+function classicItems(source, options) {
+  const slots = source?.classicSessions || source?.classicSlots || []
+  const conversion = source?.programmeCreatedFromWeek ?? source?.programmes?.programmeCreatedFromWeek ?? options.programmeCreatedFromWeek
+  const items = []
+  for (const [index, slot] of (Array.isArray(slots) ? slots : []).entries()) {
+    if (!slot || typeof slot !== 'object') continue
+    if (slot.rest === true || String(slot.mode || slot.kind || '').toLowerCase() === 'rest') continue
+    if (conversion && slot.convertedWeekKey && slot.convertedWeekKey === conversion) continue
+    const date = validISODate(slot.projectedDate) || validISODate(slot.nominalDate) || validISODate(slot.date)
+    if (!date) continue
+    const instanceId = slot.instanceId || slot.id || `classic:${date}:${slot.routineId || index}`
+    items.push({
+      instanceId,
+      source: 'classic',
+      routineId: slot.routineId ?? null,
+      programmeId: null,
+      cycleId: null,
+      sessionTemplateId: null,
+      weekIndex: null,
+      weekday: weekdayOf(date),
+      ordinal: numberOr(slot.ordinal, index + 1),
+      nominalDate: date,
+      projectedDate: date,
+      locationId: slot.locationId ?? null,
+      cycleCreatedAt: millis(slot.createdAt) || Number.MAX_SAFE_INTEGER,
+      routineSnapshot: clone(slot.routineSnapshot || slot.routine || null),
+      _session: clone(slot),
+      status: slot.completed === true ? 'completed' : 'pending',
+      partial: false,
+      owed: false,
+      miss: false,
+      blocked: false,
+      sameInstance: false,
+      attemptCount: 0,
+      recordId: null,
+      latestRecord: null,
+      bypassed: false,
+      guardUntil: null
+    })
+  }
+  return items
+}
+
+function sourceCycles(source) {
+  if (Array.isArray(source)) return source
+  if (Array.isArray(source?.cycles)) return source.cycles
+  if (Array.isArray(source?.programmes?.cycles)) return source.programmes.cycles
+  return []
+}
+
+function sourceWorkouts(source) {
+  return Array.isArray(source?.workouts) ? source.workouts : []
+}
+
+/**
+ * Adapt the persisted store shape to the pure queue projection. Legacy `S.programmes` arrays are
+ * intentionally not interpreted as cycles; only the versioned object namespace is eligible here.
+ */
+
+function classicSlotsFromWeek(source, options = {}) {
+  const week = (source?.week && typeof source.week === 'object' && !Array.isArray(source.week)) ? source.week : {}
+  const dayPlan = (source?.dayPlan && typeof source.dayPlan === 'object' && !Array.isArray(source.dayPlan)) ? source.dayPlan : {}
+  const marker = source?.programmes?.programmeCreatedFromWeek ?? source?.programmeCreatedFromWeek ?? options.programmeCreatedFromWeek
+  const now = options.now ?? Date.now()
+  const tz = options.timeZone || deviceTimeZone()
+  const today = isoAt(now, tz)
+  const wd = weekdayOf(today)
+  const monday = addDays(today, wd === 1 ? 0 : 1 - wd)
+  const slots = []
+  for (let d = 0; d < 7; d++) {
+    const iso = addDays(monday, d)
+    const wday = d + 1
+    let entries = []
+    if (Array.isArray(dayPlan[iso])) {
+      entries = dayPlan[iso].map((entry, i) => ({ routineId: entry?.routineId ?? entry, ordinal: i + 1 }))
+    } else if (week[wday]) {
+      entries = [{ routineId: week[wday], ordinal: 1 }]
+    }
+    for (const e of entries) {
+      if (!e.routineId) continue
+      slots.push({
+        instanceId: 'classic:' + iso + ':' + e.routineId,
+        nominalDate: iso,
+        projectedDate: iso,
+        routineId: e.routineId,
+        ordinal: e.ordinal,
+        ...(marker ? { convertedWeekKey: marker } : {})
+      })
+    }
+  }
+  return slots
+}
+
+export function projectStateQueue(state = {}, options = {}) {
+  const source = state?.S && typeof state.S === 'object' ? state.S : state
+  const programmes = source?.programmes && !Array.isArray(source.programmes) && typeof source.programmes === 'object'
+    ? source.programmes
+    : {}
+  const provided = options.classicSessions ?? source?.classicSessions ?? source?.classicSlots
+  const classicSessions = Array.isArray(provided)
+    ? clone(provided)
+    : classicSlotsFromWeek(source, options)
+  return projectProgrammeQueue({
+    programmes: { ...clone(programmes), cycles: Array.isArray(programmes.cycles) ? clone(programmes.cycles) : [] },
+    workouts: clone(source?.workouts || []),
+    classicSessions
+  }, options)
+}
+
+function dedupeInstances(items, diagnostics) {
+  const seen = new Map()
+  const result = []
+  for (const item of [...items].sort(itemComparator)) {
+    if (!seen.has(item.instanceId)) {
+      seen.set(item.instanceId, item)
+      result.push(item)
+      continue
+    }
+    diagnostics.push({ reason: 'duplicate-instance', instanceId: item.instanceId, kept: seen.get(item.instanceId).cycleId, dropped: item.cycleId })
+  }
+  return result
+}
+
+/**
+ * Project active Programme cycles and classic slots without persisting queue position.
+ * `items` contains settled and unsettled rows for diagnostics. Each active cycle gets its own
+ * ordered queue/front/guard state; the aggregate fields are convenience projections for callers
+ * that render one mixed schedule surface.
+ */
+export function projectProgrammeQueue(source = {}, options = {}) {
+  const resolved = { now: options.now ?? Date.now(), timeZone: options.timeZone || deviceTimeZone(), ...options }
+  const diagnostics = []
+  const cycles = sourceCycles(source)
+    .filter(cycle => cycleStatus(cycle) === 'active')
+    .sort((a, b) => cycleComparator({ cycle: a }, { cycle: b }))
+  const candidates = []
+  for (const cycle of cycles) {
+    const materialized = materializeCycleInstancesWithDiagnostics(cycle, resolved)
+    candidates.push(...materialized.items)
+    diagnostics.push(...materialized.diagnostics)
+  }
+  candidates.push(...classicItems(source, resolved))
+  const unique = dedupeInstances(candidates, diagnostics)
+  const latestRecords = recordsByInstance(sourceWorkouts(source))
+  const byCycle = new Map()
+  for (const item of unique) {
+    if (item.source !== 'programme') continue
+    const list = byCycle.get(item.cycleId) || []
+    list.push(item)
+    byCycle.set(item.cycleId, list)
+  }
+  const cycleResults = cycles.map(cycle => {
+    const settled = settleAndSlide(byCycle.get(cycle.id) || [], latestRecords, sourceWorkouts(source), resolved)
+    return { cycle, ...settled }
+  })
+  // Cross-cycle slide-collision resolution (owner D2: never double-book). Deliberate
+  // nominal-date sessions are always retained; overdue fronts that slid to the same date
+  // keep the oldest cycle on that date and shift newer cycles forward one day per collision.
+  {
+    const claimedSlideDates = new Set()
+    for (const result of cycleResults) {
+      const frontItem = result.front
+      if (!frontItem) continue
+      if (frontItem.nominalDate === frontItem.projectedDate) continue
+      let delta = 0
+      while (claimedSlideDates.has(addDays(frontItem.projectedDate, delta))) delta += 1
+      if (delta > 0) {
+        for (const item of result.ordered) item.projectedDate = addDays(item.projectedDate, delta)
+      }
+      claimedSlideDates.add(frontItem.projectedDate)
+    }
+  }
+  const cycleQueues = cycleResults.map(result => ({
+    cycleId: result.cycle.id,
+    items: result.ordered,
+    queue: result.queue,
+    owed: result.owed,
+    front: result.front,
+    eligible: result.eligible,
+    blocked: result.blocked
+  }))
+  const programmeFronts = cycleResults.map(result => result.front).filter(Boolean)
+  const programmeQueue = cycleResults.flatMap(result => result.queue)
+  const programmeOwed = cycleResults.flatMap(result => result.owed)
+  const programmeEligible = cycleResults.flatMap(result => result.eligible)
+  const blockedByCycle = Object.fromEntries(cycleResults
+    .filter(result => result.blocked)
+    .map(result => [result.cycle.id, result.blocked]))
+  const classic = unique.filter(item => item.source === 'classic')
+  {
+    const claimed = new Set()
+    for (const item of [...classic].sort((a, b) => a.ordinal - b.ordinal)) {
+      const found = latestClassicRecord(item, sourceWorkouts(source))
+      if (found && !claimed.has(found.record.id)) {
+        claimed.add(found.record.id)
+        item._claimedRecord = found.record.id
+      } else {
+        item._claimedRecord = null
+      }
+    }
+  }
+    const classicResult = settleAndSlide(classic, latestRecords, sourceWorkouts(source), resolved)
+  const classicSettled = classicResult.ordered
+  const classicQueue = classicResult.queue
+  const classicFront = classicResult.front
+  const classicBlocked = classicResult.blocked
+  const classicEligible = classicResult.eligible
+  const fronts = [...programmeFronts, classicFront].filter(Boolean).sort((a, b) => {
+    const aFront = a.status === 'owed' || a.status === 'invalid' ? 0 : 1
+    const bFront = b.status === 'owed' || b.status === 'invalid' ? 0 : 1
+    return aFront - bFront || itemComparator(a, b)
+  })
+  const front = fronts[0] || null
+  const globalQueue = [...programmeQueue, ...classicQueue].sort((a, b) => {
+    const aFront = a.status === 'owed' || a.status === 'invalid' ? 0 : 1
+    const bFront = b.status === 'owed' || b.status === 'invalid' ? 0 : 1
+    return aFront - bFront || itemComparator(a, b)
+  })
+  for (const item of globalQueue) item.bypassed = item !== front
+  const blockedBySource = { ...blockedByCycle, ...(classicBlocked ? { classic: classicBlocked } : {}) }
+  const frontResult = front?.source === 'programme'
+    ? cycleResults.find(result => result.cycle.id === front.cycleId)
+    : front?.source === 'classic' ? classicResult : null
+  const frontIsEligible = !!frontResult?.eligible?.some(item => item.instanceId === front.instanceId)
+  // The mixed queue has one authority: a guarded or invalid head blocks every later source.
+  // Per-cycle `eligible` values remain available in cycleQueues for diagnostics only.
+  const eligible = frontIsEligible ? [front] : []
+  const allItems = [...cycleResults.flatMap(result => result.ordered), ...classicSettled].sort(itemComparator)
+  return {
+    now: resolved.now,
+    timeZone: timeZoneOrLocal(resolved.timeZone),
+    items: allItems,
+    queue: globalQueue,
+    cycleQueues,
+    programmeFronts,
+    fronts,
+    owed: [...programmeOwed, ...classicResult.owed].sort(itemComparator),
+    front,
+    eligible,
+    blocked: front?.source === 'programme'
+      ? blockedByCycle[front.cycleId] || null
+      : front?.source === 'classic' ? classicBlocked : null,
+    blockedByCycle,
+    blockedBySource,
+    dispositions: {
+      ...(Array.isArray(source?.programmes?.skippedInstanceIds)
+        ? source.programmes.skippedInstanceIds.reduce((acc, id) => {
+          if (typeof id !== 'string' || !id) return acc
+          acc[id] = { version: 1, disposition: 'skip', instanceId: id }
+          return acc
+        }, {})
+        : {}),
+      ...(source?.programmeDispositions?.entries ?? {})
+    },
+    diagnostics
+  }
+}
+
+/** Return projected rows on one calendar date while retaining source immutability. */
+export function projectedSessionsForDate(source = {}, date, options = {}) {
+  const result = projectProgrammeQueue(source, options)
+  const target = validISODate(date)
+  return target ? result.items.filter(item => item.projectedDate === target) : []
+}
+
+// Named aliases keep the per-cycle seam explicit for callers that already have one cycle.
+export const projectCycleQueue = (cycle, options = {}) =>
+  projectProgrammeQueue({ cycles: [cycle], workouts: options.workouts || [] }, options)
+
+export const isProgrammeSessionOwed = record => classifyRecord(record).status === 'owed'
+
+
+/** Build the durable 'finish and skip' disposition record for a programme instance. */
+export function buildProgrammeSkipDisposition(active = {}, options = {}) {
+  const now = options.now ?? Date.now()
+  const timeZone = options.timeZone || deviceTimeZone()
+  const nominalDate = validISODate(active?.nominalDate) || null
+  return {
+    version: 1,
+    disposition: 'skip',
+    instanceId: active?.instanceId || null,
+    programmeId: active?.programmeId || null,
+    cycleId: active?.cycleId || null,
+    ...(nominalDate ? { nominalDate } : {}),
+    timeZone,
+    calendarDate: isoAt(now, timeZone),
+    recordedAt: new Date(now).toISOString()
+  }
+}
+
+/** Return the still-visible skip/finish dispositions from a queue projection. */
+export function visibleProgrammeDispositions(result = {}, options = {}) {
+  const entries = result?.dispositions || {}
+  const list = []
+  for (const [instanceId, disposition] of Object.entries(entries)) {
+    if (!disposition || typeof disposition !== 'object') continue
+    const raw = disposition.disposition
+    if (raw !== 'skip' && raw !== 'finish') continue
+    const status = raw === 'skip' ? 'skipped' : 'finished'
+    list.push({ instanceId, status, ...disposition })
+  }
+  return list
+}
+
+
+/** Start surface for the workout chooser: the aggregate queue projection with the
+ * programme front exposed as the authoritative head (guarded/owed heads never
+ * bypassed by classic routines). */
+export function programmeStartSurface(state = {}, options = {}) {
+  return projectStateQueue(state, options)
+}

--- a/frontend/src/lib/programmes.test.js
+++ b/frontend/src/lib/programmes.test.js
@@ -1,0 +1,412 @@
+import { describe, expect, it } from 'vitest'
+import {
+  HOUR,
+  DAY,
+  programmeInstanceMarker,
+  scheduleWriteContext,
+  week1StartDate,
+  materializeCycleInstances,
+  projectProgrammeQueue,
+  projectStateQueue,
+  projectedSessionsForDate
+} from './programmes.js'
+
+const session = (id, weekday, routineId = id, muscles = { chest: 1 }) => ({
+  id,
+  routineId,
+  weekday,
+  routine: {
+    id: routineId,
+    name: routineId,
+    ex: [{ id: `${id}-exercise`, sets: 3, reps: 5, muscleWeights: muscles }]
+  }
+})
+
+const cycle = ({
+  id = 'cycle-1',
+  createdAt = '2026-01-01T08:00:00.000Z',
+  week1StartDate = '2026-02-23',
+  sessions = [session('push', 1), session('pull', 3, 'pull', { back: 1 })]
+} = {}) => ({
+  id,
+  programmeId: `programme-${id}`,
+  programmeRevision: 1,
+  status: 'active',
+  createdAt,
+  startedAt: `${week1StartDate}T08:00:00.000Z`,
+  week1StartDate,
+  timeZone: 'Europe/Zurich',
+  snapshot: { weeks: [{ id: `${id}-week-1`, mode: 'normal', days: sessions.map(s => ({ weekday: s.weekday, sessions: [s] })) }] }
+})
+
+const marker = (instanceId, overrides = {}) => ({
+  version: 1,
+  instanceId,
+  programmeId: 'programme-cycle-1',
+  cycleId: 'cycle-1',
+  sessionTemplateId: instanceId.replace('pi:cycle-1:', ''),
+  ...overrides
+})
+
+const workout = (instanceId, end, overrides = {}) => ({
+  id: `workout-${instanceId}-${end}`,
+  end,
+  programmeInstance: marker(instanceId),
+  entries: [{
+    id: 'press',
+    muscleWeights: { chest: 1 },
+    sets: [{ phase: 'work', done: true, w: 40, r: 5 }]
+  }],
+  ...overrides
+})
+
+const project = (input, now = Date.parse('2026-02-26T12:00:00.000Z')) =>
+  projectProgrammeQueue(input, { now, timeZone: 'Europe/Zurich' })
+
+describe('Programme calendar and write-time context', () => {
+  it('starts Week 1 today on Monday and on the next Monday otherwise', () => {
+    expect(week1StartDate({ now: '2026-02-23T09:00:00.000Z', timeZone: 'Europe/Zurich' })).toBe('2026-02-23')
+    expect(week1StartDate({ now: '2026-02-24T09:00:00.000Z', timeZone: 'Europe/Zurich' })).toBe('2026-03-02')
+  })
+
+  it('stores the IANA timezone, offset, and local calendar date without mutating input', () => {
+    const input = { now: '2026-07-01T12:00:00.000Z', timeZone: 'America/New_York' }
+    const copy = { ...input }
+    expect(scheduleWriteContext(input)).toMatchObject({
+      timeZone: 'America/New_York',
+      offsetMinutes: -240,
+      calendarDate: '2026-07-01'
+    })
+    expect(input).toEqual(copy)
+  })
+
+  it('captures the offset at write time across a DST transition instead of using a fixed zone offset', () => {
+    expect(scheduleWriteContext({ now: '2026-03-29T00:30:00.000Z', timeZone: 'Europe/Zurich' }).offsetMinutes).toBe(60)
+    expect(scheduleWriteContext({ now: '2026-03-29T01:30:00.000Z', timeZone: 'Europe/Zurich' }).offsetMinutes).toBe(120)
+  })
+
+  it('creates a versioned nested marker while retaining flat active fields as a compatibility source', () => {
+    expect(programmeInstanceMarker({
+      programmeId: 'p1', cycleId: 'c1', instanceId: 'pi:c1:s1', sessionId: 's1',
+      weekIndex: 1, weekday: 1, ordinal: 1, nominalDate: '2026-02-23'
+    })).toEqual({
+      version: 1, instanceId: 'pi:c1:s1', programmeId: 'p1', cycleId: 'c1',
+      sessionTemplateId: 's1', weekIndex: 1, weekday: 1, ordinal: 1, nominalDate: '2026-02-23'
+    })
+  })
+
+  it('keeps a cycle calendar anchor stable across travel and DST projection', () => {
+    const source = cycle({ week1StartDate: '2026-03-02', sessions: [session('push', 1)] })
+    const before = materializeCycleInstances(source, { now: Date.parse('2026-03-08T12:00:00Z'), timeZone: 'Europe/Zurich' })
+    const after = materializeCycleInstances(source, { now: Date.parse('2026-03-09T12:00:00Z'), timeZone: 'America/Los_Angeles' })
+    expect(before[0].nominalDate).toBe('2026-03-02')
+    expect(after[0].nominalDate).toBe('2026-03-02')
+    expect(source.week1StartDate).toBe('2026-03-02')
+  })
+
+  it('keeps repeated template ids distinct across weeks and does not drop a later instance', () => {
+    const source = cycle({ sessions: [session('same', 1)] })
+    source.snapshot.weeks.push({
+      weekIndex: 2,
+      mode: 'normal',
+      days: [{ weekday: 1, sessions: [session('same', 1)] }]
+    })
+
+    const materialized = materializeCycleInstances(source)
+    expect(materialized.map(item => item.instanceId)).toEqual([
+      'pi:cycle-1:w1:d1:o1:same',
+      'pi:cycle-1:w2:d1:o1:same'
+    ])
+    const result = project({ cycles: [source] })
+    expect(result.items.filter(item => item.cycleId === 'cycle-1')).toHaveLength(2)
+    expect(result.diagnostics).not.toContainEqual(expect.objectContaining({ reason: 'duplicate-instance' }))
+  })
+
+  it('derives a queue from the versioned state namespace without mutating state', () => {
+    const source = {
+      programmes: { version: 1, cycles: [cycle()] },
+      workouts: []
+    }
+    const before = JSON.parse(JSON.stringify(source))
+    expect(projectStateQueue(source, { now: Date.parse('2026-02-26T12:00:00Z'), timeZone: 'UTC' }).front)
+      .toMatchObject({ source: 'programme', instanceId: 'pi:cycle-1:push' })
+    expect(source).toEqual(before)
+  })
+})
+
+describe('D4-aware Programme queue projection', () => {
+  it('keeps an unlogged session pending without inventing a miss or owed item', () => {
+    const result = project({ cycles: [cycle()] })
+    const item = result.items.find(item => item.instanceId === 'pi:cycle-1:push')
+    expect(item).toMatchObject({ status: 'pending', owed: false, miss: false })
+    expect(result.owed).toEqual([])
+    expect(result.front.instanceId).toBe('pi:cycle-1:push')
+  })
+
+  it('keeps a below-thirty-percent partial at the front with the same stable instance id', () => {
+    const result = project({
+      cycles: [cycle()],
+      workouts: [workout('pi:cycle-1:push', Date.parse('2026-02-25T12:00:00Z'), {
+        partial: true, complete: false, owed: true, schedule: 'repeat',
+        completion: { completedWorkSets: 1, prescribedWorkSets: 4, thresholdMet: false }
+      })]
+    })
+    expect(result.front).toMatchObject({ instanceId: 'pi:cycle-1:push', status: 'owed', owed: true, sameInstance: true })
+    expect(result.owed.map(item => item.instanceId)).toEqual(['pi:cycle-1:push'])
+    expect(result.items.find(item => item.instanceId === 'pi:cycle-1:push').projectedDate).toBe('2026-02-26')
+  })
+
+  it('advances a thirty-percent-or-more partial while retaining partial visibility', () => {
+    const result = project({
+      cycles: [cycle()],
+      workouts: [workout('pi:cycle-1:push', Date.parse('2026-02-25T12:00:00Z'), {
+        partial: true, complete: false, owed: false, schedule: 'advance',
+        completion: { completedWorkSets: 3, prescribedWorkSets: 10, thresholdMet: true }
+      })]
+    })
+    expect(result.items.find(item => item.instanceId === 'pi:cycle-1:push')).toMatchObject({
+      status: 'partial-advanced', partial: true, owed: false, miss: false
+    })
+    expect(result.front.instanceId).toBe('pi:cycle-1:pull')
+    expect(result.owed).toEqual([])
+  })
+
+  it('treats explicit Finish as settled and never queues it again', () => {
+    const result = project({
+      cycles: [cycle()],
+      workouts: [workout('pi:cycle-1:push', Date.parse('2026-02-25T12:00:00Z'), { complete: true, partial: false })]
+    })
+    expect(result.items.find(item => item.instanceId === 'pi:cycle-1:push')).toMatchObject({ status: 'completed', owed: false })
+    expect(result.front.instanceId).toBe('pi:cycle-1:pull')
+  })
+
+  it('does not duplicate a retry and resolves the latest same-instance record deterministically', () => {
+    const instanceId = 'pi:cycle-1:push'
+    const result = project({
+      cycles: [cycle()],
+      workouts: [
+        workout(instanceId, Date.parse('2026-02-24T12:00:00Z'), { partial: true, complete: false, owed: true, schedule: 'repeat' }),
+        workout(instanceId, Date.parse('2026-02-25T12:00:00Z'), { complete: true, partial: false })
+      ]
+    })
+    expect(result.items.filter(item => item.instanceId === instanceId)).toHaveLength(1)
+    expect(result.items.find(item => item.instanceId === instanceId)).toMatchObject({ status: 'completed', attemptCount: 2 })
+  })
+
+  it('fails closed on an unclassified partial instead of bypassing it', () => {
+    const result = project({
+      cycles: [cycle()],
+      workouts: [workout('pi:cycle-1:push', Date.parse('2026-02-25T12:00:00Z'), { partial: true, complete: false })]
+    })
+    expect(result.front).toMatchObject({ status: 'invalid', blocked: true })
+    expect(result.blocked).toMatchObject({ reason: 'unclassified-record', bypassed: false })
+    expect(result.eligible).toEqual([])
+  })
+
+  it('honours an explicit Finish-and-skip override below thirty percent after reload', () => {
+    const result = project({
+      cycles: [cycle()],
+      workouts: [workout('pi:cycle-1:push', Date.parse('2026-02-25T12:00:00Z'), {
+        partial: true, complete: false, owed: false, schedule: 'advance', exitIntent: 'skip',
+        completion: { completedWorkSets: 1, prescribedWorkSets: 4, thresholdMet: false }
+      })]
+    })
+    expect(result.items.find(item => item.instanceId === 'pi:cycle-1:push')).toMatchObject({
+      status: 'partial-advanced', partial: true, owed: false
+    })
+  })
+
+  it('honours an explicit Continue override at or above thirty percent after reload', () => {
+    const result = project({
+      cycles: [cycle()],
+      workouts: [workout('pi:cycle-1:push', Date.parse('2026-02-25T12:00:00Z'), {
+        partial: true, complete: false, owed: true, schedule: 'repeat', exitIntent: 'continue',
+        completion: { completedWorkSets: 3, prescribedWorkSets: 10, thresholdMet: true }
+      })]
+    })
+    expect(result.front).toMatchObject({ status: 'owed', owed: true, partial: true })
+  })
+})
+
+describe('Programme ordering, slide, guard, and classic boundaries', () => {
+  it('fails closed on contradictory threshold and owed signals', () => {
+    const result = project({
+      cycles: [cycle()],
+      workouts: [workout('pi:cycle-1:push', Date.parse('2026-02-25T12:00:00Z'), {
+        partial: true, complete: false, owed: true, schedule: 'repeat',
+        completion: { completedWorkSets: 3, prescribedWorkSets: 10, thresholdMet: true }
+      })]
+    })
+    expect(result.front).toMatchObject({ status: 'invalid', blocked: true })
+    expect(result.blocked.reason).toBe('contradictory-threshold')
+    expect(result.eligible).toEqual([])
+  })
+
+  it('orders same-day sessions chronologically and older cycles first on ties regardless of input order', () => {
+    const older = cycle({ id: 'older', createdAt: '2026-01-01T08:00:00Z', sessions: [session('morning', 1), session('evening', 1)] })
+    const newer = cycle({ id: 'newer', createdAt: '2026-01-02T08:00:00Z', sessions: [session('newer', 1)] })
+    const result = project({ cycles: [newer, older] }, Date.parse('2026-02-20T12:00:00.000Z'))
+    expect(result.items.filter(item => item.nominalDate === '2026-02-23').map(item => item.instanceId)).toEqual([
+      'pi:older:morning', 'pi:older:evening', 'pi:newer:newer'
+    ])
+  })
+
+  it('slides later sessions instead of cramming them behind an overdue owed head', () => {
+    const result = project({
+      cycles: [cycle({ sessions: [session('push', 1), session('pull', 3)] })],
+      workouts: [workout('pi:cycle-1:push', Date.parse('2026-02-20T12:00:00Z'), {
+        partial: true, complete: false, owed: true, schedule: 'repeat'
+      })]
+    })
+    expect(result.items.find(item => item.instanceId === 'pi:cycle-1:push').projectedDate).toBe('2026-02-26')
+    expect(result.items.find(item => item.instanceId === 'pi:cycle-1:pull').projectedDate).toBe('2026-02-27')
+    expect(result.eligible.map(item => item.instanceId)).toEqual(['pi:cycle-1:push'])
+  })
+
+  it('blocks an owed head below 48 hours on any primary or secondary muscle overlap and allows exactly 48 hours', () => {
+    const owedId = 'pi:cycle-1:push'
+    const base = {
+      cycles: [cycle()],
+      workouts: [workout(owedId, Date.parse('2026-02-24T12:00:00Z'), {
+        partial: true, complete: false, owed: true, schedule: 'repeat'
+      })]
+    }
+    const blocked = project(base, Date.parse('2026-02-26T11:59:59.999Z'))
+    expect(blocked.front.instanceId).toBe(owedId)
+    expect(blocked.blocked).toMatchObject({ reason: 'recovery-overlap', bypassed: false })
+    expect(blocked.eligible).toEqual([])
+
+    const allowed = project(base, Date.parse('2026-02-26T12:00:00.000Z'))
+    expect(allowed.front.instanceId).toBe(owedId)
+    expect(allowed.blocked).toBeNull()
+    expect(allowed.eligible[0].instanceId).toBe(owedId)
+  })
+
+  it('does not bypass a guarded owed head with a later session', () => {
+    const result = project({
+      cycles: [cycle({ sessions: [session('push', 1), session('pull', 1, 'pull', { chest: 1 })] })],
+      workouts: [workout('pi:cycle-1:push', Date.parse('2026-02-26T11:00:00Z'), {
+        partial: true, complete: false, owed: true, schedule: 'repeat'
+      })]
+    })
+    expect(result.front.instanceId).toBe('pi:cycle-1:push')
+    expect(result.eligible).toEqual([])
+    expect(result.items.find(item => item.instanceId === 'pi:cycle-1:pull').bypassed).toBe(true)
+  })
+
+  it('keeps active-cycle fronts independent while preserving each cycle\'s guard state', () => {
+    const older = cycle({ id: 'older', createdAt: '2026-01-01T08:00:00Z', sessions: [session('push', 1)] })
+    const newer = cycle({ id: 'newer', createdAt: '2026-01-02T08:00:00Z', sessions: [session('pull', 1, 'pull', { back: 1 })] })
+    const result = project({
+      cycles: [newer, older],
+      workouts: [workout('pi:older:push', Date.parse('2026-02-26T11:00:00Z'), {
+        partial: true, complete: false, owed: true, schedule: 'repeat'
+      })]
+    })
+    expect(result.fronts.map(item => item.instanceId)).toEqual(['pi:older:push', 'pi:newer:pull'])
+    expect(result.blockedByCycle.older).toMatchObject({ reason: 'recovery-overlap' })
+    expect(result.eligible).toEqual([])
+    expect(result.items.find(item => item.instanceId === 'pi:newer:pull').bypassed).toBe(true)
+  })
+
+  it('keeps classic Rest scoped to classic slots and suppresses only explicitly converted duplicates', () => {
+    const classic = [
+      { instanceId: 'classic-rest', source: 'classic', nominalDate: '2026-02-23', rest: true },
+      { instanceId: 'classic-converted', source: 'classic', nominalDate: '2026-02-23', convertedWeekKey: '2026-W09' },
+      { instanceId: 'classic-normal', source: 'classic', nominalDate: '2026-02-24', routineId: 'classic' }
+    ]
+    const noConversion = project({ cycles: [], classicSessions: classic })
+    expect(noConversion.items.map(item => item.instanceId)).toEqual(['classic-converted', 'classic-normal'])
+
+    const conversion = project({ cycles: [], classicSessions: classic, programmeCreatedFromWeek: '2026-W09' })
+    expect(conversion.items.map(item => item.instanceId)).toEqual(['classic-normal'])
+    expect(classic[1]).toHaveProperty('convertedWeekKey', '2026-W09')
+  })
+
+  it('settles a classic slot from matching legacy history instead of replaying it', () => {
+    const result = project({
+      classicSessions: [{ instanceId: 'classic-push', nominalDate: '2026-02-23', routineId: 'classic' }],
+      workouts: [{
+        id: 'classic-history', d: '2026-02-23', end: Date.parse('2026-02-23T12:00:00Z'),
+        routineId: 'classic', entries: [{ id: 'press', sets: [{ phase: 'work', done: true }] }]
+      }]
+    }, Date.parse('2026-02-24T12:00:00Z'))
+    expect(result.items.find(item => item.instanceId === 'classic-push')).toMatchObject({
+      status: 'completed', sameInstance: true
+    })
+    expect(result.queue).toEqual([])
+  })
+
+  it('applies the same 48-hour guard to a classic front without letting Programme Rest affect it', () => {
+    const classic = [{
+      instanceId: 'classic-push', source: 'classic', nominalDate: '2026-02-23', routineId: 'classic',
+      routineSnapshot: { ex: [{ id: 'press', muscleWeights: { chest: 1 } }] }
+    }]
+    const result = project({
+      classicSessions: classic,
+      workouts: [{
+        id: 'classic-history', end: Date.parse('2026-02-26T11:00:00Z'),
+        entries: [{ id: 'press', muscleWeights: { chest: 1 }, sets: [{ phase: 'work', done: true }] }]
+      }]
+    })
+    expect(result.front).toMatchObject({ instanceId: 'classic-push', source: 'classic', blocked: true })
+    expect(result.blocked).toMatchObject({ reason: 'recovery-overlap', bypassed: false })
+    expect(result.eligible).toEqual([])
+  })
+
+  it('canonicalizes new primary and secondary arrays before recovery overlap', () => {
+    const aliasCycle = cycle({
+      sessions: [{
+        id: 'array-session', weekday: 1,
+        routine: { id: 'array-routine', ex: [{ id: 'press', primaries: ['pectorals'], secondaries: ['triceps'] }] }
+      }]
+    })
+    const result = project({
+      cycles: [aliasCycle],
+      workouts: [{
+        id: 'array-history', end: Date.parse('2026-02-26T11:00:00Z'),
+        entries: [{ id: 'row', muscleWeights: { chest: 1 }, sets: [{ phase: 'work', done: true }] }]
+      }]
+    })
+    expect(result.blocked).toMatchObject({ reason: 'recovery-overlap' })
+  })
+
+  it('canonicalizes primary and secondary muscle aliases for the recovery overlap guard', () => {
+    const aliasCycle = cycle({
+      sessions: [{
+        id: 'alias-session', weekday: 1,
+        routine: { id: 'alias-routine', ex: [{ id: 'press', primaryMuscles: ['pectorals'] }] }
+      }]
+    })
+    const result = project({
+      cycles: [aliasCycle],
+      workouts: [{
+        id: 'alias-history', end: Date.parse('2026-02-26T11:00:00Z'),
+        entries: [{ id: 'row', secondaryMuscles: ['chest'], sets: [{ phase: 'work', done: true }] }]
+      }]
+    })
+    expect(result.blocked).toMatchObject({ reason: 'recovery-overlap' })
+  })
+
+  it('reports duplicate instance ids instead of double-booking them', () => {
+    const duplicate = cycle({
+      id: 'cycle-2',
+      sessions: [{ ...session('push', 1), instanceId: 'pi:cycle-1:push' }]
+    })
+    const result = project({ cycles: [cycle(), duplicate] })
+    expect(result.items.filter(item => item.instanceId === 'pi:cycle-1:push')).toHaveLength(1)
+    expect(result.diagnostics.some(item => item.reason === 'duplicate-instance')).toBe(true)
+  })
+
+  it('projects a date without mutating cycles or raw schedules', () => {
+    const source = { cycles: [cycle()], classicSessions: [] }
+    const before = JSON.parse(JSON.stringify(source))
+    expect(projectedSessionsForDate(source, '2026-02-23', { now: Date.parse('2026-02-23T12:00:00Z'), timeZone: 'UTC' }))
+      .toHaveLength(1)
+    expect(source).toEqual(before)
+  })
+})
+
+// Keep the public constants exercised so the boundary remains explicit in reviews.
+expect(HOUR * 48).toBe(48 * HOUR)
+expect(DAY).toBe(24 * HOUR)

--- a/frontend/src/locales/de.js
+++ b/frontend/src/locales/de.js
@@ -586,5 +586,6 @@ export default {
   '{0} sets · {1} work': '{0} Sätze · {1} Arbeit',
   'Make superset with previous': 'Mit vorheriger Übung kombinieren',
   'Make superset with next': 'Mit nächster Übung kombinieren',
-  'Unpair': 'Trennen'
+  'Unpair': 'Trennen',
+  'Primary muscle groups': 'Primäre Muskelgruppen',
 }

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -569,5 +569,6 @@ export default {
   '{0} sets · {1} work': '{0} series · {1} trabajo',
   'Make superset with previous': 'Hacer superserie con anterior',
   'Make superset with next': 'Hacer superserie con siguiente',
-  'Unpair': 'Desvincular'
+  'Unpair': 'Desvincular',
+  'Primary muscle groups': 'Grupos musculares primarios',
 }

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -569,5 +569,6 @@ export default {
   '{0} sets · {1} work': '{0} séries · {1} travail',
   'Make superset with previous': 'Faire un superset avec le précédent',
   'Make superset with next': 'Faire un superset avec le suivant',
-  'Unpair': 'Dissocier'
+  'Unpair': 'Dissocier',
+  'Primary muscle groups': 'Groupes musculaires principaux',
 }

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -569,5 +569,6 @@ export default {
   '{0} sets · {1} work': '{0} सेट · {1} काम',
   'Make superset with previous': 'पिछले के साथ सुपरसेट',
   'Make superset with next': 'अगले के साथ सुपरसेट',
-  'Unpair': 'अलग करें'
+  'Unpair': 'अलग करें',
+  'Primary muscle groups': 'प्राथमिक मांसपेशी समूह',
 }

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -569,5 +569,6 @@ export default {
   '{0} sets · {1} work': '{0} serie · {1} lavoro',
   'Make superset with previous': 'Superset con il precedente',
   'Make superset with next': 'Superset con il successivo',
-  'Unpair': 'Separa'
+  'Unpair': 'Separa',
+  'Primary muscle groups': 'Gruppi muscolari primari',
 }

--- a/frontend/src/locales/ko.js
+++ b/frontend/src/locales/ko.js
@@ -569,5 +569,6 @@ export default {
   '{0} sets · {1} work': '{0} 세트 · {1} 작업',
   'Make superset with previous': '이전 운동과 슈퍼셋',
   'Make superset with next': '다음 운동과 슈퍼셋',
-  'Unpair': '분리'
+  'Unpair': '분리',
+  'Primary muscle groups': '주요 근육 그룹',
 }

--- a/frontend/src/locales/pl.js
+++ b/frontend/src/locales/pl.js
@@ -569,5 +569,6 @@ export default {
   '{0} sets · {1} work': '{0} serii · {1} praca',
   'Make superset with previous': 'Połącz z poprzednim',
   'Make superset with next': 'Połącz z następnym',
-  'Unpair': 'Rozłącz'
+  'Unpair': 'Rozłącz',
+  'Primary muscle groups': 'Podstawowe grupy mięśniowe',
 }

--- a/frontend/src/locales/pt.js
+++ b/frontend/src/locales/pt.js
@@ -569,5 +569,6 @@ export default {
   '{0} sets · {1} work': '{0} séries · {1} trabalho',
   'Make superset with previous': 'Fazer superset com o anterior',
   'Make superset with next': 'Fazer superset com o próximo',
-  'Unpair': 'Desfazer'
+  'Unpair': 'Desfazer',
+  'Primary muscle groups': 'Grupos musculares primários',
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -569,5 +569,6 @@ export default {
   '{0} sets · {1} work': '{0} подходов · {1} рабочих',
   'Make superset with previous': 'Суперсет с предыдущим',
   'Make superset with next': 'Суперсет со следующим',
-  'Unpair': 'Разъединить'
+  'Unpair': 'Разъединить',
+  'Primary muscle groups': 'Основные группы мышц',
 }

--- a/frontend/src/locales/tr.js
+++ b/frontend/src/locales/tr.js
@@ -569,5 +569,6 @@ export default {
   '{0} sets · {1} work': '{0} set · {1} çalışma',
   'Make superset with previous': 'Öncekiyle superset yap',
   'Make superset with next': 'Sonrakiyle superset yap',
-  'Unpair': 'Ayır'
+  'Unpair': 'Ayır',
+  'Primary muscle groups': 'Birincil kas grupları',
 }

--- a/frontend/src/locales/zh.js
+++ b/frontend/src/locales/zh.js
@@ -569,5 +569,6 @@ export default {
   '{0} sets · {1} work': '{0} 组 · {1} 工作',
   'Make superset with previous': '与上一个组成超级组',
   'Make superset with next': '与下一个组成超级组',
-  'Unpair': '取消组合'
+  'Unpair': '取消组合',
+  'Primary muscle groups': '主要肌群',
 }

--- a/frontend/src/sheets.jsx
+++ b/frontend/src/sheets.jsx
@@ -11,7 +11,7 @@ import { starterRoutines } from './lib/starter.js'
 import Media, { Thumb } from './components/Media.jsx'
 import Stepper from './components/Stepper.jsx'
 import Icon from './components/Icon.jsx'
-import { Button, Slider, Switch, Segmented, SelectRow, Row } from './components/ui.jsx'
+import { Button, Slider, Switch, Segmented, SelectRow, Row, MultiSelectRow } from './components/ui.jsx'
 import { glyphOf, GLYPH_GROUPS, DEFAULT_GLYPH } from './lib/glyphs.js'
 import BodyMap from './components/BodyMap.jsx'
 import { loadOfWorkouts } from './lib/muscles.js'
@@ -346,6 +346,18 @@ function CustomExForm({ existing, prefill, onDone, close }) {
   const [n, setN] = useState(existing ? existing.n : (prefill || ''))
   const [bp, setBp] = useState(existing ? existing.bp : '')
   const [desc, setDesc] = useState(existing ? (existing.desc || '') : '')
+  const [primaries, setPrimaries] = useState(() => {
+    if (existing && Array.isArray(existing.primaries) && existing.primaries.length) return [...existing.primaries]
+    const norm = hasExplicitMuscleMetadata(existing || {}) ? normalizeMuscleGroups(existing || {}) : []
+    return norm.length ? [norm[0]] : []
+  })
+  const [secondaries, setSecondaries] = useState(() => {
+    if (existing && Array.isArray(existing.primaries) && existing.primaries.length) return [...(existing.secondaries || [])]
+    const norm = hasExplicitMuscleMetadata(existing || {}) ? normalizeMuscleGroups(existing || {}) : []
+    return norm.slice(1)
+  })
+  const togglePrimary = value => setPrimaries(current => current.includes(value) ? current.filter(m => m !== value) : [...current, value])
+  const toggleSecondary = value => setSecondaries(current => current.includes(value) ? current.filter(m => m !== value) : [...current, value])
   const save = () => {
     const name = n.trim()
     if (!name) { toast(t('Give it a name')); return }
@@ -353,11 +365,16 @@ function CustomExForm({ existing, prefill, onDone, close }) {
     const dup = allExercises(S()).find(e => e.n.toLowerCase() === name.toLowerCase() && e.id !== (existing || {}).id)
     if (dup) { toast(t('“{0}” already exists', dup.n)); return }
     const d = desc.trim().slice(0, 1000)
+    const prim = [...primaries]
+    const sm = secondaries.filter(m => !prim.includes(m))
+    const groups = [...prim, ...sm]
     let id = existing && existing.id
-    if (existing) update(s => { const c = (s.customEx || []).find(x => x.id === id); if (c) { c.n = name; c.bp = bp; c.desc = d } })
+    if (existing) update(s => { const c = (s.customEx || []).find(x => x.id === id); if (c) {
+      c.n = name; c.bp = bp; c.desc = d; c.tg = prim[0] || ''; c.sm = sm; c.muscleGroups = groups; c.primaries = prim; c.secondaries = sm
+    } })
     else {
       id = 'c' + uid()
-      update(s => { (s.customEx = s.customEx || []).push({ id, n: name, bp, desc: d, tg: '', eq: 'custom', custom: true }) })
+      update(s => { (s.customEx = s.customEx || []).push({ id, n: name, bp, desc: d, tg: prim[0] || '', sm, muscleGroups: groups, primaries: prim, secondaries: sm, eq: 'custom', custom: true }) })
     }
     close()
     toast(existing ? t('Saved') : t('“{0}” created', name))
@@ -370,6 +387,16 @@ function CustomExForm({ existing, prefill, onDone, close }) {
     <div className="chips" style={{ margin: '12px 0' }}>
       {BODYPARTS.map(b => <button key={b} className={'chip' + (bp === b ? ' on' : '')} onClick={() => setBp(b)}>{t(b)}</button>)}
     </div>
+    {bp && bp !== 'cardio' && <>
+      <MultiSelectRow title={t('Primary muscle groups')} sheetTitle={t('Primary muscle groups')}
+        values={primaries}
+        options={MUSCLES.map(m => ({ value: m, label: t(MUSCLE_NAME[m]) }))}
+        onToggle={togglePrimary} noneLabel={t('No explicit muscle group')} doneLabel={t('Done')} />
+      <MultiSelectRow title={t('Additional muscle groups')} sheetTitle={t('Additional muscle groups')}
+        values={secondaries}
+        options={MUSCLES.filter(m => !primaries.includes(m)).map(m => ({ value: m, label: t(MUSCLE_NAME[m]) }))}
+        onToggle={toggleSecondary} noneLabel={t('No explicit muscle group')} doneLabel={t('Done')} />
+    </>}
     {bp === 'cardio' && <div className="small dim row" style={{ marginBottom: 10, gap: 5 }}><Icon name="figureRun" style={{ fontSize: 13 }} />{t('Cardio exercises log time + speed instead of weight × reps.')}</div>}
     <textarea className="input" rows={4} maxLength={1000} placeholder={t('Description (optional) — setup, cues, anything you want to remember')}
       value={desc} onChange={e => setDesc(e.target.value)} />


### PR DESCRIPTION
This one grew out of the muscle-map work: the catalogue's muscle data was a single target muscle per exercise, which made the map and the recovery overlap rough for compound lifts. The proposal, in case it helps the discussion:

- **Multi-primary model**: exercises can declare `primaries[]` and `secondaries[]` (secondary muscles count at 0.4 weight), plus `full body` as a body part. The raw generated catalogue is left untouched — a small runtime overlay enriches the index, so the exercise count stays exactly 1324 and nothing about searching or filtering changes.
- **Two ExRx-informed batches**: 104 compound lifts (squat/deadlift/bench/OHP/row/pull-up families) and 119 machine exercises, each with proper primary + secondary muscle lists. Overrides stay separate from generated data for future corrections.
- **Custom exercise editor**: the muscle picker is now two multi-select dropdowns (Primary muscle groups / Additional muscle groups) so a custom exercise can carry several primaries too — same model, same map, same recovery math.

The model reads legacy fields (`tg`/`sm`/`muscleGroups`) as fallbacks, so nothing existing changes behaviour until the batch metadata kicks in. Happy to adjust batch entries if any look off — they're generated data, meant to be corrected, not worshipped.