### PR TITLE
feat: undo finish - restore the session you just completed

### DIFF
--- a/frontend/src/locales/de.js
+++ b/frontend/src/locales/de.js
@@ -139,6 +139,7 @@ export default {
   'PRs': 'Rekorde',
   'New PR:': 'Neuer Rekord:',
   'Nice!': 'Stark!',
+  'Undo finish': 'Training rückgängig machen',
   'Nothing logged yet': 'Noch nichts eingetragen',
   'You haven’t checked off any sets. Finish the workout anyway?': 'Du hast noch keine Sätze abgehakt. Training trotzdem beenden?',
   'Finish anyway': 'Trotzdem beenden',

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -133,6 +133,7 @@ export default {
   'PRs': 'Récords',
   'New PR:': 'Nuevo récord:',
   'Nice!': '¡Genial!',
+  'Undo finish': 'Deshacer finalización',
   'Nothing logged yet': 'Nada registrado aún',
   'You haven’t checked off any sets. Finish the workout anyway?': 'No has marcado ninguna serie. ¿Terminar el entrenamiento igualmente?',
   'Finish anyway': 'Terminar igualmente',

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -133,6 +133,7 @@ export default {
   'PRs': 'Records',
   'New PR:': 'Nouveau record :',
   'Nice!': 'Bien joué !',
+  'Undo finish': 'Annuler la fin',
   'Nothing logged yet': 'Rien de noté',
   'You haven’t checked off any sets. Finish the workout anyway?': 'Tu n’as coché aucune série. Terminer la séance quand même ?',
   'Finish anyway': 'Terminer quand même',

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -133,6 +133,7 @@ export default {
   'PRs': 'रिकॉर्ड',
   'New PR:': 'नया रिकॉर्ड:',
   'Nice!': 'बहुत बढ़िया!',
+  'Undo finish': 'समाप्ति पूर्ववत करें',
   'Nothing logged yet': 'अभी कुछ दर्ज नहीं',
   'You haven’t checked off any sets. Finish the workout anyway?': 'आपने कोई सेट चेक नहीं किया। फिर भी वर्कआउट समाप्त करें?',
   'Finish anyway': 'फिर भी समाप्त करें',

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -133,6 +133,7 @@ export default {
   'PRs': 'Record',
   'New PR:': 'Nuovo record:',
   'Nice!': 'Grande!',
+  'Undo finish': 'Annulla fine',
   'Nothing logged yet': 'Niente registrato',
   'You haven’t checked off any sets. Finish the workout anyway?': 'Non hai spuntato nessuna serie. Terminare comunque?',
   'Finish anyway': 'Termina comunque',

--- a/frontend/src/locales/ko.js
+++ b/frontend/src/locales/ko.js
@@ -133,6 +133,7 @@ export default {
   'PRs': '신기록',
   'New PR:': '신기록:',
   'Nice!': '좋아요!',
+  'Undo finish': '운동 완료 취소',
   'Nothing logged yet': '아직 기록 없음',
   'You haven’t checked off any sets. Finish the workout anyway?': '체크한 세트가 없어요. 그래도 운동을 마칠까요?',
   'Finish anyway': '그래도 마치기',

--- a/frontend/src/locales/pl.js
+++ b/frontend/src/locales/pl.js
@@ -133,6 +133,7 @@ export default {
   'PRs': 'Rekordy',
   'New PR:': 'Nowy rekord:',
   'Nice!': 'Świetnie!',
+  'Undo finish': 'Cofnij zakończenie',
   'Nothing logged yet': 'Nic nie zapisano',
   'You haven’t checked off any sets. Finish the workout anyway?': 'Nie odhaczyłeś żadnej serii. Mimo to zakończyć trening?',
   'Finish anyway': 'Zakończ mimo to',

--- a/frontend/src/locales/pt.js
+++ b/frontend/src/locales/pt.js
@@ -133,6 +133,7 @@ export default {
   'PRs': 'Recordes',
   'New PR:': 'Novo recorde:',
   'Nice!': 'Boa!',
+  'Undo finish': 'Anular conclusão',
   'Nothing logged yet': 'Ainda nada registado',
   'You haven’t checked off any sets. Finish the workout anyway?': 'Não marcaste nenhuma série. Terminar o treino mesmo assim?',
   'Finish anyway': 'Terminar mesmo assim',

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -133,6 +133,7 @@ export default {
   'PRs': 'Рекорды',
   'New PR:': 'Новый рекорд:',
   'Nice!': 'Отлично!',
+  'Undo finish': 'Отменить завершение',
   'Nothing logged yet': 'Пока ничего не записано',
   'You haven’t checked off any sets. Finish the workout anyway?': 'Ни один подход не отмечен. Всё равно завершить тренировку?',
   'Finish anyway': 'Всё равно завершить',

--- a/frontend/src/locales/tr.js
+++ b/frontend/src/locales/tr.js
@@ -133,6 +133,7 @@ export default {
   'PRs': 'Rekorlar',
   'New PR:': 'Yeni rekor:',
   'Nice!': 'Süper!',
+  'Undo finish': 'Bitirmeyi geri al',
   'Nothing logged yet': 'Henüz kayıt yok',
   'You haven’t checked off any sets. Finish the workout anyway?': 'Hiç set işaretlemedin. Yine de antrenman bitsin mi?',
   'Finish anyway': 'Yine de bitir',

--- a/frontend/src/locales/zh.js
+++ b/frontend/src/locales/zh.js
@@ -133,6 +133,7 @@ export default {
   'PRs': '纪录',
   'New PR:': '新纪录：',
   'Nice!': '太棒了！',
+  'Undo finish': '撤销结束',
   'Nothing logged yet': '还没有记录',
   'You haven’t checked off any sets. Finish the workout anyway?': '你还没有勾选任何组。仍要结束训练吗？',
   'Finish anyway': '仍然结束',

--- a/frontend/src/sheets.jsx
+++ b/frontend/src/sheets.jsx
@@ -834,6 +834,8 @@ export function beginWorkout(routineId, bw) {
     return { id: cfg.id, sg: cfg.sg, target: { ...cfg }, plan, sets: applyPrescription(buildSets(st, cfg), plan) }
   })
   update(s => {
+    s.lastFinishedSession = null
+    s.lastFinishedUndo = null
     s.active = { id: uid(), d: todayISO(), start: Date.now(), routineId, name: r ? r.name : t('Freestyle'), bw: bw || null, cur: 0, entries }
   })
   useUI.getState().stopRest()
@@ -901,6 +903,50 @@ function WorkoutComplete({ close }) {
   </div>
 }
 export const workoutCompleteSheet = () => ui().openSheet(close => <WorkoutComplete close={close} />, { kind: 'center' })
+function rollbackFinishedSideEffects(state, undo) {
+  if (!undo) return
+  const workouts = Array.isArray(state.workouts) ? state.workouts : (state.workouts = [])
+  if (undo.replacedWorkout) {
+    const currentIndex = workouts.findIndex(workout => (
+      (undo.instanceId && workout.instanceId === undo.instanceId)
+      || (workout.id === undo.workoutId && workout.end === undo.workoutEnd)
+    ))
+    if (currentIndex >= 0) workouts[currentIndex] = cloneJson(undo.replacedWorkout)
+    else {
+      const index = Math.max(0, Math.min(undo.replacedIndex, workouts.length))
+      workouts.splice(index, 0, cloneJson(undo.replacedWorkout))
+    }
+  } else {
+    const currentIndex = workouts.findIndex(workout => workout.id === undo.workoutId && workout.end === undo.workoutEnd)
+    if (currentIndex >= 0) workouts.splice(currentIndex, 1)
+  }
+  const previousExWeights = undo.previousExWeights || {}
+  state.exWeights = state.exWeights && typeof state.exWeights === 'object' ? state.exWeights : {}
+  Object.entries(previousExWeights).forEach(([id, previous]) => {
+    if (previous?.present) state.exWeights[id] = cloneJson(previous.value)
+    else delete state.exWeights[id]
+  })
+  if (Object.prototype.hasOwnProperty.call(undo, 'programmesBefore')) state.programmes = cloneJson(undo.programmesBefore)
+}
+
+export function undoFinish() {
+  const snapshot = S().lastFinishedSession
+  if (!snapshot || S().active) return false
+  useUI.getState().closeAll()
+  let restored = false
+  update(s => {
+    if (!s.lastFinishedSession || s.active) return
+    rollbackFinishedSideEffects(s, s.lastFinishedUndo)
+    s.active = cloneJson(s.lastFinishedSession)
+    s.lastFinishedSession = null
+    s.lastFinishedUndo = null
+    restored = true
+  })
+  if (!restored) return false
+  nav('/workout')
+  return true
+}
+
 
 function FinishSummary({ w, prs, e1prs = [], close }) {
   const st = useStore(s => s.S)
@@ -921,6 +967,8 @@ function FinishSummary({ w, prs, e1prs = [], close }) {
     <BodyMap load={loadOfWorkouts([w])} body={st.body} />
     <div style={{ height: 14 }} />
     <Button variant="primary" onClick={() => { close(); nav('/home') }}>{t('Nice!')}</Button>
+    <div style={{ height: 8 }} />
+    <Button variant="ghost" icon="reset" onClick={() => { close(); undoFinish() }}>{t('Undo finish')}</Button>
   </div>
 }
 export function finishWorkout() {
@@ -936,6 +984,7 @@ function doFinishWorkout() {
   const st = S()
   const A = st.active
   if (!A) return
+  const finishedSession = cloneJson(A)
   const prs = []
   const e1prs = []
   A.entries.forEach(e => {
@@ -955,12 +1004,24 @@ function doFinishWorkout() {
     prs
   }
   w.vol = workoutVolume(w)
+  const finishedUndo = {
+    workoutId: w.id,
+    workoutEnd: w.end,
+    replacedIndex: -1,
+    replacedWorkout: null,
+    previousExWeights: Object.fromEntries(A.entries.map(entry => {
+      const present = Object.prototype.hasOwnProperty.call(st.exWeights || {}, entry.id)
+      return [entry.id, { present, value: present ? cloneJson(st.exWeights[entry.id]) : null }]
+    }))
+  }
   update(s => {
     w.entries.forEach(e => {
       const mx = Math.max(0, ...e.sets.filter(x => x.done).map(x => x.w || 0), e.topW || 0)
       if (mx > 0) { const cur = s.exWeights[e.id]; if (!cur || mx > cur.w) s.exWeights[e.id] = { w: mx, d: w.d } }
     })
     s.workouts.push(w)
+    s.lastFinishedSession = finishedSession
+    s.lastFinishedUndo = finishedUndo
     s.active = null
   })
   useUI.getState().stopRest()

--- a/frontend/src/store/useStore.js
+++ b/frontend/src/store/useStore.js
@@ -11,7 +11,7 @@ export const DEF = {
   unit: 'kg', restSec: 90, sound: true, keepAwake: true, lang: 'en',
   theme: 'dark', accent: 'lime', body: 'male', targetW: null,
   bodyweight: [], routines: [], week: {}, dayPlan: {},
-  exWeights: {}, workouts: [], active: null, customEx: [], gifSize: 'full',
+exWeights: {}, workouts: [], active: null, lastFinishedSession: null, lastFinishedUndo: null, customEx: [], gifSize: 'full',
   // effort: which per-set effort scale is logged — 'none' | 'rir' | 'rpe'. null, not 'none', so
   // that a profile which never chose (loaded state is overlaid on DEF, on every path: local,
   // server pull, backup import) still falls back to the `showRir` boolean this replaced and


### PR DESCRIPTION
A small quality-of-life addition that grew out of the finish flow: after you hit “Nice!” you sometimes immediately realise you mis-tapped a set, or that the session you just completed should have been the same session you were working on. This lets you take the finish back:

- **Undo finish** button on the completion summary (ghost style, right under “Nice!”)
- Restores the exact finished session — including unchecked sets, the timer state, and the navigation — as a fresh active workout
- Rolls back the completion record and the weight cache (`exWeights`) to what they were before the finish, so nothing is double-counted
- Only the immediately finished session is undoable; starting a new workout clears the snapshot

The snapshot (`lastFinishedSession`) and the undo record (`lastFinishedUndo`) are plain state fields with no behaviour change when unused — existing saved states stay valid. The programme-partial replacement path we use internally is not included here since the session-programme machinery isn't in main yet; happy to add it once that lands.