### PR TITLE
feat: weekly view — day selector strip, per-day session card, day view sheet

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -324,17 +324,17 @@ h4.sec{
   background:none;border:none;transition:background var(--fast);
 }
 .wday .lbl{font-size:11px;color:var(--label-3);font-weight:500;text-transform:uppercase;letter-spacing:.03em}
-.wday .num{font-size:17px;font-weight:400;margin:4px 0;letter-spacing:-.012em}
-.wday .dot{width:5px;height:5px;border-radius:50%;background:transparent;margin:0 auto}
+.wday .num{font-size:17px;font-weight:400;margin:2px auto;letter-spacing:-.012em;
+  width:31px;height:31px;border-radius:50%;display:flex;align-items:center;justify-content:center}
+.wday .dot{width:5px;height:5px;border-radius:50%;background:transparent;margin:9px auto 0}
 .wday .dot.plan{background:var(--label-3)}
 .wday .dot.ovr{background:var(--orange)}
 .wday .dot.done{background:var(--acc)}
 .wday:active{background:var(--surface-2)}
-.wday.today .num{
-  background:var(--acc);color:var(--on-acc);font-weight:600;
-  width:31px;height:31px;border-radius:50%;display:flex;align-items:center;
-  justify-content:center;margin:2px auto;
-}
+.wday.today .num{background:var(--acc);color:var(--on-acc);font-weight:600}
+.wday.sel .num{outline:2px solid var(--acc);outline-offset:2px}
+.wday.today.sel .num{outline-color:var(--orange)}
+.wday.sel{background:color-mix(in srgb,var(--acc) 8%,transparent)}
 
 /* ----------------------------------------------------------------- list -- */
 .list{display:flex;flex-direction:column;gap:8px}

--- a/frontend/src/lib/programmes-ui.js
+++ b/frontend/src/lib/programmes-ui.js
@@ -1,0 +1,184 @@
+import { t } from './i18n-core.js'
+
+const COLOURS = Object.freeze({
+  lime: 'var(--green)',
+  sky: 'var(--blue)',
+  orange: 'var(--orange)',
+  gold: 'var(--yellow)',
+  violet: 'var(--purple)',
+  pink: 'var(--pink)',
+  teal: 'var(--teal)',
+})
+
+const sourceOf = state => state?.S && typeof state.S === 'object' ? state.S : (state || {})
+const namespaceOf = state => {
+  const source = sourceOf(state)
+  return source.programmes && !Array.isArray(source.programmes) && typeof source.programmes === 'object'
+    ? source.programmes
+    : source.version === 1 && (Array.isArray(source.cycles) || Array.isArray(source.definitions))
+      ? source
+      : {}
+}
+const idOf = value => value?.id ?? value?.programmeId ?? null
+const cycleProgrammeId = cycle => cycle?.programmeId ?? cycle?.definitionId ?? cycle?.programme?.id ?? null
+const cycleId = cycle => cycle?.id ?? cycle?.cycleId ?? null
+const pad = value => String(value).padStart(2, '0')
+const validISO = value => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : null
+const dateNumber = value => {
+  const iso = validISO(value)
+  return iso ? Date.UTC(Number(iso.slice(0, 4)), Number(iso.slice(5, 7)) - 1, Number(iso.slice(8, 10))) : NaN
+}
+const addDays = (value, amount) => {
+  const at = dateNumber(value)
+  return Number.isFinite(at) ? new Date(at + Number(amount || 0) * 86400000).toISOString().slice(0, 10) : null
+}
+const isoAt = (now, timeZone) => {
+  try {
+    const parts = Object.fromEntries(new Intl.DateTimeFormat('en-CA', {
+      timeZone: timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+    }).formatToParts(new Date(now)).filter(part => part.type !== 'literal').map(part => [part.type, part.value]))
+    return `${parts.year}-${pad(parts.month)}-${pad(parts.day)}`
+  } catch {
+    const date = new Date(now)
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+  }
+}
+const mondayOnOrAfter = (value) => {
+  const at = dateNumber(value)
+  if (!Number.isFinite(at)) return null
+  const weekday = new Date(at).getUTCDay() || 7
+  return addDays(value, weekday === 1 ? 0 : 8 - weekday)
+}
+const weeksOf = cycle => {
+  if (Array.isArray(cycle?.programmeSnapshot?.weeks)) return cycle.programmeSnapshot.weeks
+  if (Array.isArray(cycle?.snapshot?.weeks)) return cycle.snapshot.weeks
+  if (Array.isArray(cycle?.snapshot)) return cycle.snapshot
+  return Array.isArray(cycle?.weeks) ? cycle.weeks : []
+}
+const daysOf = week => Array.isArray(week?.days)
+  ? week.days.map((day, index) => [day, Number(day?.weekday ?? day?.day ?? index + 1) || index + 1])
+  : Object.entries(week?.days || {}).map(([weekday, day], index) => [day, Number(day?.weekday ?? weekday) || index + 1])
+const sessionsOf = day => day?.rest === true || day?.mode === 'rest' || !Array.isArray(day?.sessions) ? [] : day.sessions
+const markerOf = workout => workout?.programmeInstance?.instanceId || workout?.instanceId || workout?.programme?.instanceId || null
+const routineName = value => value?.name || value?.title || null
+const usableRoutine = value => value && (routineName(value) || Array.isArray(value.ex)) ? value : null
+
+function definitions(state) {
+  const namespace = namespaceOf(state)
+  for (const key of ['definitions', 'programmes', 'templates']) {
+    if (Array.isArray(namespace[key])) return namespace[key]
+  }
+  return []
+}
+
+function definitionFor(state, programmeId) {
+  return definitions(state).find(definition => String(idOf(definition)) === String(programmeId)) || null
+}
+
+function cycleFor(state, wantedId) {
+  return (namespaceOf(state).cycles || []).find(cycle => String(cycleId(cycle)) === String(wantedId)) || null
+}
+
+export function programmeNameForItem(state, item) {
+  const cycle = cycleFor(state, item?.cycleId)
+  const definition = definitionFor(state, item?.programmeId)
+  return cycle?.programmeSnapshot?.name || cycle?.programme?.name || definition?.name || definition?.title || item?.programmeId || t('Programme')
+}
+
+export function programmeLabelForItem(state, item) {
+  const source = sourceOf(state)
+  const snapshot = usableRoutine(item?.routineSnapshot)
+  const live = (source.routines || []).find(candidate => String(candidate.id) === String(item?.routineId))
+  const routine = routineName(snapshot) ? snapshot : (live || snapshot)
+  return `${programmeNameForItem(state, item)} · ${routineName(routine) || item?.routineId || t('Routine')}`
+}
+
+export function programmeColourForItem(state, item) {
+  if (!item) return null
+  const cycle = cycleFor(state, item.cycleId)
+  const definition = definitionFor(state, item.programmeId)
+  const raw = cycle?.programmeSnapshot?.colour ?? cycle?.programmeSnapshot?.color
+    ?? cycle?.colour ?? cycle?.color ?? definition?.colour ?? definition?.color
+  return COLOURS[String(raw || '').trim().toLowerCase()] || null
+}
+
+function materializeCycle(state, cycle, now) {
+  const status = String(cycle?.status || '').toLowerCase()
+  if (!['active', 'running', 'current', 'completed', 'complete', 'done', 'finished'].includes(status)) return []
+  const currentDate = isoAt(now, cycle?.timeZone)
+  const anchor = validISO(cycle?.week1StartDate)
+    || mondayOnOrAfter(validISO(cycle?.calendarDate) || isoAt(cycle?.startedAt || cycle?.createdAt || now, cycle?.timeZone))
+  if (!anchor) return []
+  const source = sourceOf(state)
+  const records = new Map((source.workouts || []).map(workout => [markerOf(workout), workout]).filter(([id]) => id))
+  const skipped = new Set(namespaceOf(state).skippedInstanceIds || [])
+  const items = []
+  const templateCounts = new Map()
+  weeksOf(cycle).forEach(week => daysOf(week).forEach(([day]) => sessionsOf(day).forEach((session, sessionIndex) => {
+    const snapshot = session?.routineSnapshot || session?.routine || session?.snapshot || null
+    const routineId = session?.routineId ?? snapshot?.id ?? null
+    const templateId = session?.sessionTemplateId ?? session?.templateId ?? session?.id ?? `${routineId || 'session'}:${sessionIndex + 1}`
+    templateCounts.set(templateId, (templateCounts.get(templateId) || 0) + 1)
+  })))
+  weeksOf(cycle).forEach((week, weekOffset) => {
+    if (week?.rest === true || week?.mode === 'rest') return
+    const weekIndex = Number(week?.weekIndex ?? week?.index ?? weekOffset + 1) || weekOffset + 1
+    daysOf(week).forEach(([day, rawWeekday]) => {
+      const weekday = rawWeekday === 0 ? 7 : Math.max(1, Math.min(7, rawWeekday))
+      sessionsOf(day).forEach((session, sessionIndex) => {
+        const snapshot = session?.routineSnapshot || session?.routine || session?.snapshot || null
+        const routineId = session?.routineId ?? snapshot?.id ?? null
+        const templateId = session?.sessionTemplateId ?? session?.templateId ?? session?.id ?? `${routineId || 'session'}:${sessionIndex + 1}`
+        const explicitInstanceId = typeof session?.instanceId === 'string' && session.instanceId ? session.instanceId : null
+        const instanceId = explicitInstanceId || (templateCounts.get(templateId) > 1
+          ? `pi:${cycleId(cycle)}:w${weekIndex}:d${weekday}:o${sessionIndex + 1}:${templateId}`
+          : `pi:${cycleId(cycle)}:${templateId}`)
+        const record = records.get(instanceId)
+        items.push({
+          instanceId,
+          source: 'programme',
+          programmeId: cycleProgrammeId(cycle),
+          cycleId: cycleId(cycle),
+          routineId,
+          routineSnapshot: snapshot,
+          weekIndex,
+          weekday,
+          ordinal: Number(session?.ordinal) || sessionIndex + 1,
+          nominalDate: addDays(anchor, (weekIndex - 1) * 7 + weekday - 1),
+          projectedDate: null,
+          status: record ? 'completed' : skipped.has(instanceId) ? 'skipped' : 'pending',
+          record,
+        })
+      })
+    })
+  })
+  items.sort((a, b) => a.nominalDate.localeCompare(b.nominalDate) || a.ordinal - b.ordinal || a.instanceId.localeCompare(b.instanceId))
+  let previousUnsettled = null
+  items.forEach(item => {
+    const unsettled = item.status === 'pending'
+    let projected = item.nominalDate
+    if (unsettled && projected <= currentDate) projected = currentDate
+    if (unsettled && previousUnsettled && item.nominalDate !== previousUnsettled.nominalDate) {
+      const previousShifted = previousUnsettled.projectedDate !== previousUnsettled.nominalDate || previousUnsettled.nominalDate < currentDate
+      if (previousShifted && projected <= previousUnsettled.projectedDate) projected = addDays(previousUnsettled.projectedDate, 1)
+    }
+    item.projectedDate = projected
+    if (unsettled) previousUnsettled = item
+  })
+  const completedCycle = ['completed', 'complete', 'done', 'finished'].includes(status)
+  return completedCycle ? items.filter(item => item.status !== 'pending') : items
+}
+
+/** Project all programme sessions needed by the weekly selector without mutating persisted state. */
+export function programmeItems(state, { now = Date.now() } = {}) {
+  const cycles = Array.isArray(namespaceOf(state).cycles) ? namespaceOf(state).cycles : []
+  return cycles.flatMap(cycle => materializeCycle(state, cycle, now)).sort((a, b) =>
+    a.projectedDate.localeCompare(b.projectedDate)
+      || String(a.cycleId).localeCompare(String(b.cycleId))
+      || a.ordinal - b.ordinal)
+}
+
+export function programmeItemsForDate(state, iso, options) {
+  return programmeItems(state, options).filter(item => item.projectedDate === iso)
+}

--- a/frontend/src/sheets.jsx
+++ b/frontend/src/sheets.jsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { useStore } from './store/useStore.js'
 import { useUI } from './store/useUI.js'
-import { EXDB, EXIDX, BODYPARTS, isCardio, isBodyweightEq, allExercises, equipmentOf, smOf } from './lib/exercises.js'
+import { EXDB, EXIDX, BODYPARTS, isCardio, isBodyweightEq, allExercises, equipmentOf, smOf, exOr } from './lib/exercises.js'
 import { fmtDate, fmtNum, fmtVol, fmtDur, durPart, todayISO, uid, exCount, DAYN, MONTHS_LONG, ACCENTS } from './lib/format.js'
 import { lastEntryFor, bestWeightFor, buildSets, effectiveRoutineId, workoutVolume, setsDone, setsDoneActive, lastBW, supersetUnits, unitOf, setLabel, defaultConfig, cleanupSg, modeOf, effortOf, isBw, isPerSide, sideReps, workSetsDone } from './lib/history.js'
 import { beep, vibrate } from './lib/sound.js'
-import { t, instrFor, getLang, INSTR_LANGS } from './lib/i18n.js'
+import { t, instrFor, getLang, INSTR_LANGS, dateLocale } from './lib/i18n.js'
 import { nav } from './lib/nav.js'
 import { starterRoutines } from './lib/starter.js'
 import Media, { Thumb } from './components/Media.jsx'
@@ -20,6 +20,7 @@ import { buildPlanBundle, parsePlan, mergePlan, printPlan } from './lib/plan-sha
 import { estimate1RM, best1RM, is1RMRecord, REP_CAP } from './lib/onerm.js'
 import { nextPrescription, applyPrescription, policyFor, defaultIncrement, POLICIES_FOR, POLICY_NAME, POLICY_DESC, MAX_BW_SETS } from './lib/progression.js'
 import { MOBILE, shareExport } from './lib/mobile.js'
+import { programmeColourForItem, programmeItemsForDate, programmeLabelForItem, programmeNameForItem } from './lib/programmes-ui.js'
 
 const S = () => useStore.getState().S
 const update = (...a) => useStore.getState().update(...a)
@@ -729,6 +730,153 @@ function DayOverride({ iso, close }) {
 }
 export const dayOverrideSheet = iso => ui().openSheet(close => <DayOverride iso={iso} close={close} />)
 
+function routineIdsForDate(state, iso) {
+  const hasOverride = Object.prototype.hasOwnProperty.call(state.dayPlan || {}, iso)
+  const raw = hasOverride ? state.dayPlan[iso] : state.week?.[new Date(iso + 'T12:00:00').getDay()]
+  if (raw == null || raw === '' || raw === 'rest') return []
+  const ids = Array.isArray(raw) ? raw : [raw]
+  const available = new Set((state.routines || []).map(routine => String(routine.id)))
+  return [...new Set(ids.filter(id => available.has(String(id))))]
+}
+
+function routinesForDate(state, iso) {
+  const routines = new Map((state.routines || []).map(routine => [String(routine.id), routine]))
+  return routineIdsForDate(state, iso).map(id => routines.get(String(id))).filter(Boolean)
+}
+
+function targetOf(config = {}) {
+  const nested = config.target && typeof config.target === 'object' && !Array.isArray(config.target)
+    ? config.target
+    : {}
+  // Legacy plans keep mode/sets at the top level. New snapshots can override individual
+  // prescription fields under `target`, so merge rather than discarding either shape.
+  return { ...config, ...nested }
+}
+
+function lastLoggedWorkWeight(state, exerciseId) {
+  for (let workoutIndex = (state.workouts || []).length - 1; workoutIndex >= 0; workoutIndex--) {
+    const workout = state.workouts[workoutIndex]
+    for (let entryIndex = (workout.entries || []).length - 1; entryIndex >= 0; entryIndex--) {
+      const entry = workout.entries[entryIndex]
+      if (String(entry?.id) !== String(exerciseId)) continue
+      for (let setIndex = (entry.sets || []).length - 1; setIndex >= 0; setIndex--) {
+        const set = entry.sets[setIndex]
+        const warmup = set?.warmup === true || set?.phase === 'warmup'
+        const weight = Number(set?.w ?? set?.weight)
+        if (set?.done && !warmup && Number.isFinite(weight) && weight > 0) return weight
+      }
+    }
+  }
+  return 0
+}
+
+function plannedWeightFor(state, config) {
+  const target = targetOf(config)
+  const resolved = Number(target.resolvedWeight)
+  if (Number.isFinite(resolved) && resolved > 0) return resolved
+  const prescribed = Number(target.weight)
+  if (Number.isFinite(prescribed) && prescribed > 0) return prescribed
+  return lastLoggedWorkWeight(state, config.id)
+}
+
+function plannedLine(state, config) {
+  const target = targetOf(config)
+  const sets = Math.max(1, Number(target.sets) || 1)
+  const timed = target.mode === 'time' || target.sec != null || target.seconds != null || target.time != null
+  if (timed) return `${sets} × ${Number(target.sec ?? target.seconds ?? target.time) || 0}s`
+  const cardio = target.mode === 'cardio' || target.min != null
+  if (cardio) return `${sets} × ${Number(target.min) || 0} min${target.speed ? ' @ ' + fmtNum(target.speed) + ' km/h' : ''}`
+  const reps = target.reps ?? target.r ?? ''
+  const weight = plannedWeightFor(state, config)
+  return `${sets} × ${reps}${weight > 0 ? ' @ ' + fmtNum(weight) + ' ' + (state.unit || 'kg') : ''}`
+}
+
+function DayView({ iso, close }) {
+  const state = useStore(s => s.S)
+  const plans = routinesForDate(state, iso)
+  const programmes = programmeItemsForDate(state, iso)
+  const freestyle = (state.workouts || []).filter(workout => workout.d === iso && !workout.routineId)
+  const blocks = [
+    ...plans.map(routine => ({ key: 'routine:' + routine.id, type: 'routine', routineId: routine.id, name: routine.name, emoji: routine.emoji, colour: 'var(--acc)', exercises: routine.ex || [] })),
+    ...programmes.map(item => {
+      const live = (state.routines || []).find(routine => String(routine.id) === String(item.routineId))
+      // The snapshot carries the cycle-specific targets (including editor-resolved weights).
+      // A live routine is only a compatibility fallback for old programme records.
+      const routine = Array.isArray(item.routineSnapshot?.ex) ? item.routineSnapshot : live || item.routineSnapshot || {}
+      return {
+        key: item.instanceId,
+        type: 'programme',
+        routineId: routine.id || item.routineId,
+        name: routine.name || programmeLabelForItem(state, item),
+        subtitle: programmeNameForItem(state, item),
+        emoji: routine.emoji,
+        colour: programmeColourForItem(state, item) || 'var(--surface-3)',
+        exercises: routine.ex || [],
+      }
+    }),
+    ...freestyle.map(workout => ({
+      key: 'freestyle:' + workout.id,
+      type: 'freestyle',
+      name: workout.name || t('Freestyle'),
+      emoji: null,
+      colour: 'var(--surface-2)',
+      exercises: (workout.entries || []).map(entry => ({ ...entry, target: entry.target || {} })),
+    })),
+  ]
+  const rows = blocks.flatMap(block => block.exercises.map(config => {
+    const target = targetOf(config)
+    const sets = Math.max(1, Number(target.sets) || 1)
+    const timed = target.mode === 'time' || target.sec != null || target.seconds != null || target.time != null
+    const reps = timed ? 0 : Number(target.reps ?? target.r) || 0
+    const weight = timed ? 0 : plannedWeightFor(state, config)
+    return { sets, volume: sets * reps * weight }
+  }))
+  const totalSets = rows.reduce((sum, row) => sum + row.sets, 0)
+  const totalVolume = rows.reduce((sum, row) => sum + row.volume, 0)
+  const label = iso === todayISO()
+    ? t('Today')
+    : new Date(iso + 'T12:00:00').toLocaleDateString(dateLocale(), { weekday: 'long', day: 'numeric', month: 'long' })
+  if (!blocks.length) return <>
+    <h3>{label}</h3>
+    <div className="muted" style={{ padding: '14px 4px' }}>{t('Rest day — no sessions scheduled.')}</div>
+    <div style={{ height: 10 }} /><Button variant="primary" onClick={close}>{t('Done')}</Button>
+  </>
+  return <>
+    <h3>{label}</h3>
+    <div className="small muted" style={{ marginBottom: 10 }}>
+      {[exCount(rows.length), `${totalSets} ${t('sets')}`, totalVolume > 0 ? fmtVol(totalVolume, state.unit || 'kg') : null].filter(Boolean).join(' · ')}
+    </div>
+    <div className="list">
+      {blocks.map(block => <div key={block.key} className="item" style={{ alignItems: 'flex-start', cursor: block.type === 'freestyle' ? 'default' : 'pointer' }}
+        onClick={block.type === 'freestyle' ? undefined : () => { close(); nav('/plan/r/' + block.routineId) }}>
+        <span className="lrow-i" style={{ background: block.colour }}><Icon name={block.emoji ? glyphOf(block.emoji) : 'sparkles'} /></span>
+        <div className="grow">
+          <div className="tt">{block.name}</div>
+          {block.subtitle && <div className="small muted" style={{ marginBottom: 3 }}>{block.subtitle}</div>}
+          {block.exercises.map((config, index) => {
+            const supersetStart = config.sg && block.exercises[index + 1]?.sg === config.sg && block.exercises[index - 1]?.sg !== config.sg
+            return <div key={index}>
+              {supersetStart && <div className="small accent" style={{ marginTop: 4 }}><Icon name="link" /> {t('Superset')}</div>}
+              <div className="small muted" style={{ display: 'flex', justifyContent: 'space-between', gap: 10 }}>
+                <span>{state.customEx?.find(exercise => String(exercise.id) === String(config.id))?.n || exOr(config.id).n}</span>
+                <span style={{ whiteSpace: 'nowrap' }}>{plannedLine(state, config)}</span>
+              </div>
+            </div>
+          })}
+          {!block.exercises.length && <div className="small muted">{t('No exercises')}</div>}
+          {block.type === 'freestyle' && <div className="small dim" style={{ marginTop: 5 }}>{t('Completed freestyle session')}</div>}
+        </div>
+        {block.type === 'freestyle' ? null : <Icon name="chevronRight" className="muted" />}
+      </div>)}
+    </div>
+    <div style={{ height: 10 }} /><Button variant="primary" onClick={close}>{t('Done')}</Button>
+  </>
+}
+
+export function dayViewSheet(iso) {
+  ui().openSheet(close => <DayView iso={iso} close={close} />)
+}
+
 function DayAssign({ day, close }) {
   const st = useStore(s => s.S)
   const set = v => { update(s => { if (v) s.week[day] = v; else delete s.week[day] }); close() }
@@ -820,12 +968,15 @@ export function WorkoutRow({ w, onClick }) {
 }
 
 /* ============================ workout lifecycle ============================ */
-export function startFlow(routineId) {
-  bwSheet({ required: true, onDone: bw => beginWorkout(routineId, bw) })
+export function startFlow(routineId, programmeItem = null) {
+  bwSheet({ required: true, onDone: bw => beginWorkout(routineId, bw, programmeItem) })
 }
-export function beginWorkout(routineId, bw) {
+export function beginWorkout(routineId, bw, programmeItem = null) {
   const st = S()
-  const r = routineId ? st.routines.find(x => x.id === routineId) : null
+  const routineSnapshot = programmeItem?.routineSnapshot
+  const r = Array.isArray(routineSnapshot?.ex)
+    ? routineSnapshot
+    : routineId ? st.routines.find(x => String(x.id) === String(routineId)) : null
   // The prescription is applied as the session is built, so you walk up to the bar with the
   // right weight already on the screen instead of being told about it afterwards. `plan` is
   // kept on the entry purely so the workout can explain the number it chose.
@@ -834,7 +985,19 @@ export function beginWorkout(routineId, bw) {
     return { id: cfg.id, sg: cfg.sg, target: { ...cfg }, plan, sets: applyPrescription(buildSets(st, cfg), plan) }
   })
   update(s => {
-    s.active = { id: uid(), d: todayISO(), start: Date.now(), routineId, name: r ? r.name : t('Freestyle'), bw: bw || null, cur: 0, entries }
+    s.active = {
+      id: uid(), d: todayISO(), start: Date.now(), routineId, name: r ? r.name : t('Freestyle'), bw: bw || null, cur: 0, entries,
+      ...(programmeItem?.instanceId ? {
+        sessionType: 'programme',
+        programmeInstance: {
+          instanceId: programmeItem.instanceId,
+          programmeId: programmeItem.programmeId,
+          cycleId: programmeItem.cycleId,
+          weekIndex: programmeItem.weekIndex,
+          weekday: programmeItem.weekday,
+        },
+      } : {}),
+    }
   })
   useUI.getState().stopRest()
   nav('/workout')
@@ -948,6 +1111,8 @@ function doFinishWorkout() {
   })
   const w = {
     id: A.id, d: A.d, start: A.start, end: Date.now(), routineId: A.routineId, name: A.name, bw: A.bw,
+    ...(A.sessionType ? { sessionType: A.sessionType } : {}),
+    ...(A.programmeInstance ? { programmeInstance: A.programmeInstance } : {}),
     // `target` (what the session prescribed) is kept alongside the sets: without it a
     // finished workout cannot say whether it hit its reps, and a timed session reads back
     // as "0 reps". It is what the progression engine works from.

--- a/frontend/src/views/Home.jsx
+++ b/frontend/src/views/Home.jsx
@@ -1,14 +1,44 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store/useStore.js'
-import { effectiveRoutine, effectiveRoutineId, streakWeeks, lastBW, setsDoneActive } from '../lib/history.js'
+import { streakWeeks, lastBW } from '../lib/history.js'
 import { fmtNum, fmtDate, todayISO, isoOf, weekKey, DAYS } from '../lib/format.js'
 import { t, dateLocale } from '../lib/i18n.js'
-import { bwSheet, goalSheet, dayOverrideSheet, calendarSheet, startFlow, loadStarterPlan, bwDeltaColor } from '../sheets.jsx'
+import { bwSheet, beginWorkout, goalSheet, dayOverrideSheet, dayViewSheet, calendarSheet, startFlow, loadStarterPlan, bwDeltaColor } from '../sheets.jsx'
 import LineChart from '../components/LineChart.jsx'
 import Icon from '../components/Icon.jsx'
 import { Button } from '../components/ui.jsx'
 import { glyphOf } from '../lib/glyphs.js'
+import { programmeColourForItem, programmeItems, programmeItemsForDate, programmeNameForItem } from '../lib/programmes-ui.js'
+
+function routineIdsForDate(state, iso) {
+  const hasOverride = Object.prototype.hasOwnProperty.call(state.dayPlan || {}, iso)
+  const raw = hasOverride
+    ? state.dayPlan[iso]
+    : state.week?.[new Date(iso + 'T12:00:00').getDay()]
+  if (raw == null || raw === '' || raw === 'rest') return []
+  const ids = Array.isArray(raw) ? raw : [raw]
+  const available = new Set((state.routines || []).map(routine => String(routine.id)))
+  return [...new Set(ids.filter(id => available.has(String(id))))]
+}
+
+function routinesForDate(state, iso) {
+  const routines = new Map((state.routines || []).map(routine => [String(routine.id), routine]))
+  return routineIdsForDate(state, iso).map(id => routines.get(String(id))).filter(Boolean)
+}
+
+function completedClassicRoutineIds(state, iso) {
+  const done = new Set()
+  ;(state.workouts || []).forEach(workout => {
+    if (workout?.d !== iso || !workout.routineId) return
+    const programmeMarked = workout.programmeSession === true || workout.sessionType === 'programme'
+      || workout.kind === 'programme' || workout.instanceId || workout.programmeInstance?.instanceId
+    if (!programmeMarked) done.add(String(workout.routineId))
+  })
+  return done
+}
+
+const isProgrammeDone = item => ['completed', 'complete', 'done', 'finished'].includes(String(item?.status || '').toLowerCase())
 
 // Home = what to do now + a quick glance. Deep charts & history live in Stats.
 export default function Home() {
@@ -16,34 +46,87 @@ export default function Home() {
   const S = useStore(s => s.S)
   const user = useStore(s => s.user)
   const [weekOffset, setWeekOffset] = useState(0)
+  const todayISOValue = todayISO()
+  const [selectedISO, setSelectedISO] = useState(todayISOValue)
 
-  const today = new Date()
-  const routine = effectiveRoutine(S, todayISO())
-  const todayOvr = S.dayPlan[todayISO()] !== undefined
+  const now = Date.now()
+  const today = new Date(now)
+  const selectedPlans = routinesForDate(S, selectedISO)
+  const programmeQueue = programmeItems(S, { now })
+  const selectedProgramme = programmeItemsForDate(S, selectedISO, { now })
+  const selectedFreestyle = (S.workouts || []).filter(workout => workout.d === selectedISO && !workout.routineId)
+  const doneClassic = completedClassicRoutineIds(S, selectedISO)
+  const isPast = selectedISO < todayISOValue
+  const selectedLabel = selectedISO === todayISOValue
+    ? t('Today')
+    : new Date(selectedISO + 'T12:00:00').toLocaleDateString(dateLocale(), { weekday: 'long', day: 'numeric', month: 'short' })
+  const hasDayOverride = Object.prototype.hasOwnProperty.call(S.dayPlan || {}, selectedISO)
+
   const bw = lastBW(S)
   const prevBW = S.bodyweight.length > 1 ? S.bodyweight[S.bodyweight.length - 2] : null
   const delta = bw && prevBW ? bw.w - prevBW.w : null
 
-  const monday = new Date(today); monday.setDate(today.getDate() - ((today.getDay() + 6) % 7) + weekOffset * 7)
-  const doneDays = new Set(S.workouts.map(w => w.d))
+  const monday = new Date(today)
+  monday.setDate(today.getDate() - ((today.getDay() + 6) % 7) + weekOffset * 7)
+  const unitWorkouts = S.workouts || []
+  const doneDays = new Set(unitWorkouts.map(workout => workout.d))
   const strip = []
   for (let i = 0; i < 7; i++) {
-    const d = new Date(monday); d.setDate(monday.getDate() + i)
-    const iso = isoOf(d)
-    const eff = effectiveRoutineId(S, iso), ovr = S.dayPlan[iso] !== undefined, done = doneDays.has(iso)
-    const dot = done ? ' done' : ovr && eff ? ' ovr' : eff ? ' plan' : ''
-    strip.push(<div key={i} className={'wday' + (iso === todayISO() ? ' today' : '')} onClick={() => dayOverrideSheet(iso)}>
-      <div className="lbl">{t(DAYS[d.getDay()])}</div><div className="num">{d.getDate()}</div><div className={'dot' + dot} /></div>)
+    const date = new Date(monday)
+    date.setDate(monday.getDate() + i)
+    const iso = isoOf(date)
+    const planned = routineIdsForDate(S, iso)
+    const override = Object.prototype.hasOwnProperty.call(S.dayPlan || {}, iso)
+    const done = doneDays.has(iso)
+    const programme = programmeQueue.find(item => item.projectedDate === iso && item.source === 'programme')
+    const dot = done ? ' done' : override && planned.length ? ' ovr' : planned.length ? ' plan' : ''
+    const programmeColour = programmeColourForItem(S, programme)
+    strip.push(
+      <div key={iso} className={'wday' + (iso === todayISOValue ? ' today' : '') + (iso === selectedISO ? ' sel' : '')}
+        onClick={() => setSelectedISO(iso)}
+        onContextMenu={event => { event.preventDefault(); dayOverrideSheet(iso) }}>
+        <div className="lbl">{t(DAYS[date.getDay()])}</div>
+        <div className="num">{date.getDate()}</div>
+        <div className={'dot' + dot} style={programmeColour ? { background: programmeColour } : undefined} />
+      </div>,
+    )
   }
-  const sunday = new Date(monday); sunday.setDate(monday.getDate() + 6)
-  const wkLabel = weekOffset === 0 ? t('This week') : `${monday.getDate()} ${monday.toLocaleDateString(dateLocale(), { month: 'short' })} – ${sunday.getDate()} ${sunday.toLocaleDateString(dateLocale(), { month: 'short' })}`
+  const sunday = new Date(monday)
+  sunday.setDate(monday.getDate() + 6)
+  const wkLabel = weekOffset === 0
+    ? t('This week')
+    : `${monday.getDate()} ${monday.toLocaleDateString(dateLocale(), { month: 'short' })} – ${sunday.getDate()} ${sunday.toLocaleDateString(dateLocale(), { month: 'short' })}`
+  const shiftWeek = deltaWeeks => {
+    setWeekOffset(offset => offset + deltaWeeks)
+    setSelectedISO(current => {
+      const date = new Date(current + 'T12:00:00')
+      date.setDate(date.getDate() + deltaWeeks * 7)
+      return isoOf(date)
+    })
+  }
 
-  const wThisWeek = S.workouts.filter(w => weekKey(w.d) === weekKey(todayISO())).length
-  const plannedPerWeek = Object.keys(S.week).filter(k => S.week[k]).length
-  const bwPoints = S.bodyweight.slice(-30).map(b => ({ t: b.t || new Date(b.d).getTime(), y: b.w, d: b.d }))
+  const wThisWeek = unitWorkouts.filter(workout => weekKey(workout.d) === weekKey(todayISOValue)).length
+  const plannedPerWeek = Object.keys(S.week).filter(key => S.week[key]).length
+  const bwPoints = S.bodyweight.slice(-30).map(entry => ({ t: entry.t || new Date(entry.d).getTime(), y: entry.w, d: entry.d }))
 
-  // today's session shown right under the week strip
-  const onToday = () => { if (S.active) nav('/workout'); else if (routine) startFlow(routine.id); else dayOverrideSheet(todayISO()) }
+  const startFreestyle = () => bwSheet({ required: true, locked: false, onDone: weight => beginWorkout(null, weight) })
+  const openDay = () => {
+    if (S.active) nav('/workout')
+    else if (isPast) dayViewSheet(selectedISO)
+    else dayOverrideSheet(selectedISO)
+  }
+  const noSessions = !selectedPlans.length && !selectedProgramme.length && !selectedFreestyle.length
+
+  const actionForRoutine = (routine, done, programmeItem = null) => isPast
+    ? <span className="row" style={{ gap: 8 }} onClick={event => event.stopPropagation()}>
+        {done && <Icon name="check" className="accent" />}
+        <Button variant="ghost" className="dim" size="sm" onClick={() => dayViewSheet(selectedISO)}>{t('View')}</Button>
+        <Button variant="primary" size="sm" onClick={() => startFlow(routine?.id || programmeItem?.routineId, programmeItem)}>{t('Repeat')}</Button>
+      </span>
+    : <span className="row" style={{ gap: 8 }} onClick={event => event.stopPropagation()}>
+        <Button variant="ghost" className="dim" size="sm" aria-label={t('Edit day')} onClick={() => dayOverrideSheet(selectedISO)}><Icon name="pencil" /></Button>
+        <Button variant="primary" size="sm" onClick={() => startFlow(routine?.id || programmeItem?.routineId, programmeItem)}>{t('Start')}</Button>
+      </span>
 
   return <div className="narrow">
     <div className="hdr">
@@ -53,33 +136,77 @@ export default function Home() {
 
     <div className="card">
       <div className="row between" style={{ marginBottom: 8 }}>
-        <button className="iconbtn" style={{ width: 30, height: 30, fontSize: 15 }} onClick={() => setWeekOffset(w => w - 1)} aria-label="Previous week"><Icon name="chevronLeft" /></button>
+        <button className="iconbtn" style={{ width: 30, height: 30, fontSize: 15 }} onClick={() => shiftWeek(-1)} aria-label="Previous week"><Icon name="chevronLeft" /></button>
         <div className="small muted" style={{ fontWeight: 500 }}>{wkLabel}</div>
-        <button className="iconbtn" style={{ width: 30, height: 30, fontSize: 15 }} onClick={() => setWeekOffset(w => w + 1)} aria-label="Next week"><Icon name="chevronRight" /></button>
+        <button className="iconbtn" style={{ width: 30, height: 30, fontSize: 15 }} onClick={() => shiftWeek(1)} aria-label="Next week"><Icon name="chevronRight" /></button>
       </div>
       <div className="week">{strip}</div>
-      <div className="today-row" onClick={onToday}>
+
+      {S.active ? <div className="today-row" onClick={() => nav('/workout')}>
         <div className="row" style={{ gap: 9, minWidth: 0 }}>
-          <span className="lrow-i" style={{ background: S.active ? 'var(--orange)' : routine ? 'var(--acc)' : 'var(--surface-3)' }}>
-            <Icon name={S.active ? 'timer' : routine ? glyphOf(routine.emoji) : 'moon'} />
-          </span>
-          <div style={{ minWidth: 0 }}>
-            <div className="lbl2">{t('Today')}</div>
-            <div className="ttl">{S.active ? t('{0} — in progress', S.active.name) : routine ? routine.name : t('Rest day')}{todayOvr && routine ? ' · ' + t('rescheduled') : ''}</div>
-          </div>
+          <span className="lrow-i" style={{ background: 'var(--orange)' }}><Icon name="timer" /></span>
+          <div style={{ minWidth: 0 }}><div className="lbl2">{t('Today')}</div><div className="ttl">{t('{0} — in progress', S.active.name)}</div></div>
         </div>
-        {S.active ? <span className="tag" style={{ color: 'var(--orange)', background: 'color-mix(in srgb,var(--orange) 16%,transparent)' }}>{t('Resume')}</span>
-          : routine ? <span className="tag acc">{t('Start')}</span>
-          : <Icon name="plus" className="chev" />}
-      </div>
+        <span className="tag" style={{ color: 'var(--orange)', background: 'color-mix(in srgb,var(--orange) 16%,transparent)' }}>{t('Resume')}</span>
+      </div> : <>
+        {noSessions && <div className="today-row" onClick={openDay}>
+          <div className="row" style={{ gap: 9, minWidth: 0 }}>
+            <span className="lrow-i" style={{ background: 'var(--surface-3)' }}><Icon name="moon" /></span>
+            <div style={{ minWidth: 0 }}><div className="lbl2">{selectedLabel}</div><div className="ttl">{t('Rest day')}</div></div>
+          </div>
+          {isPast
+            ? <span className="row" style={{ gap: 8 }} onClick={event => event.stopPropagation()}>
+                <Button variant="ghost" className="dim" size="sm" onClick={() => dayViewSheet(selectedISO)}>{t('View')}</Button>
+                <Button variant="primary" size="sm" onClick={startFreestyle}>{t('Repeat')}</Button>
+              </span>
+            : <span className="row" style={{ gap: 8 }} onClick={event => event.stopPropagation()}>
+                <Button variant="ghost" className="dim" size="sm" aria-label={t('Edit day')} onClick={() => dayOverrideSheet(selectedISO)}><Icon name="pencil" /></Button>
+                <Button variant="primary" size="sm" onClick={startFreestyle}>{t('Start')}</Button>
+              </span>}
+        </div>}
+
+        {selectedPlans.map((routine, index) => <div key={'routine:' + routine.id} className="today-row" style={index || noSessions ? { borderTop: '1px solid var(--line)' } : undefined} onClick={() => isPast ? dayViewSheet(selectedISO) : startFlow(routine.id)}>
+          <div className="row" style={{ gap: 9, minWidth: 0 }}>
+            <span className="lrow-i" style={{ background: 'var(--acc)' }}><Icon name={glyphOf(routine.emoji)} /></span>
+            <div style={{ minWidth: 0 }}><div className="lbl2">{selectedLabel}</div><div className="ttl">{routine.name}{hasDayOverride ? ' · ' + t('rescheduled') : ''}</div></div>
+          </div>
+          {actionForRoutine(routine, doneClassic.has(String(routine.id)))}
+        </div>)}
+
+        {selectedProgramme.map((item, index) => {
+          const liveRoutine = (S.routines || []).find(routine => String(routine.id) === String(item.routineId))
+          // Programme snapshots are the prescription the cycle was created with. Prefer one
+          // that can actually be started; falling back to the live routine keeps older cycles
+          // (which stored only an id) working without silently replacing a valid snapshot.
+          const routine = Array.isArray(item.routineSnapshot?.ex)
+            ? item.routineSnapshot
+            : liveRoutine || item.routineSnapshot || { id: item.routineId, name: t('Routine'), emoji: null }
+          return <div key={item.instanceId} className="today-row" style={selectedPlans.length || index ? { borderTop: '1px solid var(--line)' } : undefined} onClick={() => isPast ? dayViewSheet(selectedISO) : startFlow(item.routineId, item)}>
+            <div className="row" style={{ gap: 9, minWidth: 0 }}>
+              <span className="lrow-i" style={{ background: programmeColourForItem(S, item) || 'var(--surface-3)' }}><Icon name={glyphOf(routine.emoji)} /></span>
+              <div style={{ minWidth: 0 }}><div className="lbl2">{programmeNameForItem(S, item)}</div><div className="ttl">{routine.name}</div></div>
+            </div>
+            {actionForRoutine(routine, isProgrammeDone(item), item)}
+          </div>
+        })}
+
+        {selectedFreestyle.map((workout, index) => <div key={workout.id} className="today-row" style={selectedPlans.length || selectedProgramme.length || index ? { borderTop: '1px solid var(--line)' } : undefined} onClick={() => dayViewSheet(selectedISO)}>
+          <div className="row" style={{ gap: 9, minWidth: 0 }}>
+            <span className="lrow-i" style={{ background: 'var(--surface-2)' }}><Icon name="sparkles" /></span>
+            <div style={{ minWidth: 0 }}><div className="lbl2">{t('Freestyle')}</div><div className="ttl">{workout.name || t('Session')}</div></div>
+          </div>
+          <span className="row" style={{ gap: 8 }} onClick={event => event.stopPropagation()}>
+            <Icon name="check" className="accent" />
+            <Button variant="ghost" className="dim" size="sm" onClick={() => dayViewSheet(selectedISO)}>{t('View')}</Button>
+            <Button variant="primary" size="sm" onClick={startFreestyle}>{t('Repeat')}</Button>
+          </span>
+        </div>)}
+      </>}
     </div>
 
     {!S.routines.length && !S.active && (
       <div className="card">
-        <div className="row" style={{ gap: 10, marginBottom: 6 }}>
-          <span className="lrow-i"><Icon name="sparkles" /></span>
-          <div className="big" style={{ fontSize: 22 }}>{t('Welcome!')}</div>
-        </div>
+        <div className="row" style={{ gap: 10, marginBottom: 6 }}><span className="lrow-i"><Icon name="sparkles" /></span><div className="big" style={{ fontSize: 22 }}>{t('Welcome!')}</div></div>
         <div className="muted small" style={{ marginBottom: 12 }}>{t('Set up your weekly routine to get going — or load a ready-made Push / Pull / Legs plan.')}</div>
         <Button variant="primary" icon="sparkles" onClick={loadStarterPlan}>{t('Load starter plan (PPL)')}</Button>
         <div style={{ height: 8 }} /><Button onClick={() => nav('/plan')}>{t('Build my own plan')}</Button>
@@ -97,21 +224,10 @@ export default function Home() {
       {bw ? <>
         <div className="row" style={{ gap: 8, alignItems: 'baseline' }}>
           <div className="big">{fmtNum(bw.w)} <span className="muted" style={{ fontSize: '1rem' }}>{S.unit}</span></div>
-          {/* only when it actually moved — an unchanged weight used to read as "− 0" */}
-          {!!delta && (
-            <span className="small row" style={{ gap: 2, fontWeight: 500, color: bwDeltaColor(delta, bw.w) }}>
-              <Icon name={delta > 0 ? 'arrowUp' : 'arrowDown'} style={{ fontSize: 12 }} />
-              {fmtNum(Math.abs(delta))}
-            </span>
-          )}
+          {!!delta && <span className="small row" style={{ gap: 2, fontWeight: 500, color: bwDeltaColor(delta, bw.w) }}><Icon name={delta > 0 ? 'arrowUp' : 'arrowDown'} style={{ fontSize: 12 }} />{fmtNum(Math.abs(delta))}</span>}
           <span className="dim small" style={{ marginLeft: 'auto' }}>{fmtDate(bw.d, true)}</span>
         </div>
-        {S.targetW && (
-          <div className="small row" style={{ color: 'var(--yellow)', marginTop: 4, gap: 5 }}>
-            <Icon name="target" style={{ fontSize: 13 }} />
-            <span>{t('Goal')} {fmtNum(S.targetW)} {S.unit} · {Math.abs(S.targetW - bw.w) < 0.05 ? t('reached!') : t(S.targetW > bw.w ? '{0} to gain' : '{0} to lose', fmtNum(Math.abs(S.targetW - bw.w)) + ' ' + S.unit)}</span>
-          </div>
-        )}
+        {S.targetW && <div className="small row" style={{ color: 'var(--yellow)', marginTop: 4, gap: 5 }}><Icon name="target" style={{ fontSize: 13 }} /><span>{t('Goal')} {fmtNum(S.targetW)} {S.unit} · {Math.abs(S.targetW - bw.w) < 0.05 ? t('reached!') : t(S.targetW > bw.w ? '{0} to gain' : '{0} to lose', fmtNum(Math.abs(S.targetW - bw.w)) + ' ' + S.unit)}</span></div>}
         <div className="chart" style={{ marginTop: 8 }}><LineChart points={bwPoints} h={130} unit={S.unit} goal={S.targetW} /></div>
       </> : <div className="muted small">{t("No entries yet — log your weight to start the curve. It's also asked before every workout.")}</div>}
     </div>
@@ -119,11 +235,8 @@ export default function Home() {
     <div className="card tappable" style={{ cursor: 'pointer' }} onClick={() => calendarSheet()}>
       <div className="row between">
         <div>
-          <div className="row" style={{ gap: 7, fontSize: 22, fontWeight: 600, letterSpacing: '-.021em' }}>
-            <Icon name="flame" style={{ color: 'var(--orange)' }} />
-            {t('{0} week streak', streakWeeks(S))}
-          </div>
-          <div className="muted small" style={{ marginTop: 2 }}>{wThisWeek}{plannedPerWeek ? ' / ' + plannedPerWeek : ''} {t('this week')} · {t(S.workouts.length === 1 ? '{0} workout total' : '{0} workouts total', S.workouts.length)}</div>
+          <div className="row" style={{ gap: 7, fontSize: 22, fontWeight: 600, letterSpacing: '-.021em' }}><Icon name="flame" style={{ color: 'var(--orange)' }} />{t('{0} week streak', streakWeeks(S))}</div>
+          <div className="muted small" style={{ marginTop: 2 }}>{wThisWeek}{plannedPerWeek ? ' / ' + plannedPerWeek : ''} {t('this week')} · {t(unitWorkouts.length === 1 ? '{0} workout total' : '{0} workouts total', unitWorkouts.length)}</div>
         </div>
         <Icon name="calendar" className="chev" style={{ fontSize: 20 }} />
       </div>

--- a/frontend/src/views/RoutineEdit.jsx
+++ b/frontend/src/views/RoutineEdit.jsx
@@ -96,6 +96,18 @@ export default function RoutineEdit() {
     <div className="small dim row" style={{ margin: '10px 2px', gap: 5 }}><Icon name="link" style={{ fontSize: 13 }} />{t('Tap the link button on an exercise to superset it with the one above — you’ll do them back-to-back.')}</div>
     <Button variant="primary" onClick={() => exercisePicker(ex => exConfigSheet(ex, null, cfg => edit(x => { x.push({ id: ex.id, ...cfg }) }), null, r))} icon="plus">{t('Add exercise')}</Button>
     <div style={{ height: 10 }} />
+    <Button variant="ghost" icon="copy" onClick={() => {
+      const newId = uid()
+      update(s => {
+        const source = s.routines.find(candidate => candidate.id === id)
+        if (!source) return
+        // Duplicate the complete routine schema, not a hand-maintained list of fields. This
+        // keeps newer routine-level settings independent while still giving the copy a new id.
+        s.routines.push({ ...JSON.parse(JSON.stringify(source)), id: newId })
+      })
+      nav('/plan/r/' + newId)
+    }}>{t('Save as routine')}</Button>
+    <div style={{ height: 10 }} />
     <Button variant="danger" onClick={() => confirmSheet({
       title: t('Delete routine?'), message: t('“{0}” and its exercises will be removed.', r.name), confirmText: t('Delete'), danger: true,
       onConfirm: () => {


### PR DESCRIPTION
> Draft while we align the weekly view with the planning discussion in #140, #159 and #167. This branch still needs rebasing and the requested review fixes before another review.

Weekly view: day selector strip + per-day session card + day view sheet

Following up on the day-card direction, this adds a proper week strip and a much richer per-day view.

### What's in here
- **Week strip** on Home: tap any day to shift the highlight and see that day's sessions below — today keeps its filled circle, the selected day gets a ring, and the dots under each day mark overrides/done state.
- **Per-day card**: past days show **View + Repeat** (completed sessions get a check mark), current/future days show **Edit + Start**. Freestyle sessions you actually logged appear below the scheduled ones, and programme sessions are listed per session, each labelled with its programme's name (ready for multiple programmes at once).
- **Day view sheet**: tap View on any day for a compact summary — exercise count, total sets, planned volume — plus each exercise's target with the weight you'll use (editor-resolved weight, else last logged working weight). Timed sets render as `3 × 60s`, supersets included. Tapping a session opens it in the routine editor.
- **Save as routine** button in the routine editor: duplicates the complete routine (all settings, deep-copied) and opens the copy.
- Freestyle **Repeat** starts a true freestyle session (not the scheduled routine).

Original August validation: 253 tests passed and the build passed. No backend or schema changes — frontend only.

Curious what you think — happy to adjust the day-card layout or the summary format if you'd like it tighter.
