### PR TITLE
fix(i18n): strength-view strings in all 11 locales

### DIFF
--- a/frontend/src/locales/de.js
+++ b/frontend/src/locales/de.js
@@ -586,5 +586,9 @@ export default {
   '{0} sets · {1} work': '{0} Sätze · {1} Arbeit',
   'Make superset with previous': 'Mit vorheriger Übung kombinieren',
   'Make superset with next': 'Mit nächster Übung kombinieren',
+  "primary": "primär",
+  "secondary": "sekundär",
+  "No exercises with an estimated 1RM yet.": "Noch keine Übungen mit geschätztem 1RM.",
+  "Tap a muscle to see its exercises.": "Tippe auf einen Muskel, um seine Übungen zu sehen.",
   'Unpair': 'Trennen'
 }

--- a/frontend/src/locales/es.js
+++ b/frontend/src/locales/es.js
@@ -569,5 +569,9 @@ export default {
   '{0} sets · {1} work': '{0} series · {1} trabajo',
   'Make superset with previous': 'Hacer superserie con anterior',
   'Make superset with next': 'Hacer superserie con siguiente',
+  "primary": "principal",
+  "secondary": "secundario",
+  "No exercises with an estimated 1RM yet.": "Aún no hay ejercicios con 1RM estimado.",
+  "Tap a muscle to see its exercises.": "Toca un músculo para ver sus ejercicios.",
   'Unpair': 'Desvincular'
 }

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -569,5 +569,9 @@ export default {
   '{0} sets · {1} work': '{0} séries · {1} travail',
   'Make superset with previous': 'Faire un superset avec le précédent',
   'Make superset with next': 'Faire un superset avec le suivant',
+  "primary": "principal",
+  "secondary": "secondaire",
+  "No exercises with an estimated 1RM yet.": "Aucun exercice avec un 1RM estimé pour l'instant.",
+  "Tap a muscle to see its exercises.": "Touchez un muscle pour voir ses exercices.",
   'Unpair': 'Dissocier'
 }

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -569,5 +569,9 @@ export default {
   '{0} sets · {1} work': '{0} सेट · {1} काम',
   'Make superset with previous': 'पिछले के साथ सुपरसेट',
   'Make superset with next': 'अगले के साथ सुपरसेट',
+  "primary": "प्राथमिक",
+  "secondary": "द्वितीयक",
+  "No exercises with an estimated 1RM yet.": "अभी तक अनुमानित 1RM वाला कोई व्यायाम नहीं।",
+  "Tap a muscle to see its exercises.": "व्यायाम देखने के लिए किसी मांसपेशी पर टैप करें।",
   'Unpair': 'अलग करें'
 }

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -569,5 +569,9 @@ export default {
   '{0} sets · {1} work': '{0} serie · {1} lavoro',
   'Make superset with previous': 'Superset con il precedente',
   'Make superset with next': 'Superset con il successivo',
+  "primary": "primario",
+  "secondary": "secondario",
+  "No exercises with an estimated 1RM yet.": "Nessun esercizio con 1RM stimato finora.",
+  "Tap a muscle to see its exercises.": "Tocca un muscolo per vedere i suoi esercizi.",
   'Unpair': 'Separa'
 }

--- a/frontend/src/locales/ko.js
+++ b/frontend/src/locales/ko.js
@@ -569,5 +569,9 @@ export default {
   '{0} sets · {1} work': '{0} 세트 · {1} 작업',
   'Make superset with previous': '이전 운동과 슈퍼셋',
   'Make superset with next': '다음 운동과 슈퍼셋',
+  "primary": "주동",
+  "secondary": "보조",
+  "No exercises with an estimated 1RM yet.": "추정 1RM이 있는 운동이 아직 없습니다.",
+  "Tap a muscle to see its exercises.": "근육을 눌러 해당 운동을 확인하세요.",
   'Unpair': '분리'
 }

--- a/frontend/src/locales/pl.js
+++ b/frontend/src/locales/pl.js
@@ -569,5 +569,9 @@ export default {
   '{0} sets · {1} work': '{0} serii · {1} praca',
   'Make superset with previous': 'Połącz z poprzednim',
   'Make superset with next': 'Połącz z następnym',
+  "primary": "główny",
+  "secondary": "drugorzędny",
+  "No exercises with an estimated 1RM yet.": "Brak ćwiczeń z oszacowanym 1RM.",
+  "Tap a muscle to see its exercises.": "Dotknij mięśnia, aby zobaczyć jego ćwiczenia.",
   'Unpair': 'Rozłącz'
 }

--- a/frontend/src/locales/pt.js
+++ b/frontend/src/locales/pt.js
@@ -569,5 +569,9 @@ export default {
   '{0} sets · {1} work': '{0} séries · {1} trabalho',
   'Make superset with previous': 'Fazer superset com o anterior',
   'Make superset with next': 'Fazer superset com o próximo',
+  "primary": "primário",
+  "secondary": "secundário",
+  "No exercises with an estimated 1RM yet.": "Ainda não há exercícios com 1RM estimado.",
+  "Tap a muscle to see its exercises.": "Toque num músculo para ver os seus exercícios.",
   'Unpair': 'Desfazer'
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -569,5 +569,9 @@ export default {
   '{0} sets · {1} work': '{0} подходов · {1} рабочих',
   'Make superset with previous': 'Суперсет с предыдущим',
   'Make superset with next': 'Суперсет со следующим',
+  "primary": "основная",
+  "secondary": "вспомогательная",
+  "No exercises with an estimated 1RM yet.": "Пока нет упражнений с расчётным 1ПМ.",
+  "Tap a muscle to see its exercises.": "Нажмите на мышцу, чтобы увидеть её упражнения.",
   'Unpair': 'Разъединить'
 }

--- a/frontend/src/locales/tr.js
+++ b/frontend/src/locales/tr.js
@@ -569,5 +569,9 @@ export default {
   '{0} sets · {1} work': '{0} set · {1} çalışma',
   'Make superset with previous': 'Öncekiyle superset yap',
   'Make superset with next': 'Sonrakiyle superset yap',
+  "primary": "birincil",
+  "secondary": "ikincil",
+  "No exercises with an estimated 1RM yet.": "Henüz tahmini 1RM olan egzersiz yok.",
+  "Tap a muscle to see its exercises.": "Egzersizlerini görmek için bir kas seçin.",
   'Unpair': 'Ayır'
 }

--- a/frontend/src/locales/zh.js
+++ b/frontend/src/locales/zh.js
@@ -569,5 +569,9 @@ export default {
   '{0} sets · {1} work': '{0} 组 · {1} 工作',
   'Make superset with previous': '与上一个组成超级组',
   'Make superset with next': '与下一个组成超级组',
+  "primary": "主要",
+  "secondary": "次要",
+  "No exercises with an estimated 1RM yet.": "暂无估算1RM的动作。",
+  "Tap a muscle to see its exercises.": "点击肌肉查看其动作。",
   'Unpair': '取消组合'
 }


### PR DESCRIPTION
First slice of the split requested in #86: locales only, additions-only (+44 -0), 4 keys per pack.