### PR TITLE
refactor: warm-up resolver — phaseForSet/isWarmupRow + mechanical swaps

### DIFF
--- a/frontend/src/lib/effort.js
+++ b/frontend/src/lib/effort.js
@@ -8,6 +8,7 @@
 // floor of 6 is only a convention about which sets are worth rating. RPE 8 == RIR 2.
 import { EFFORT, effortOf } from './history.js'
 import { weekKey } from './format.js'
+import { isWarmupRow } from './workout-model.js'
 
 // At or below this a set is close enough to failure to be the kind that drives adaptation.
 // 3 rather than 2: the line is a convention, and drawn one rep too generously it still
@@ -44,7 +45,7 @@ export const scaleName = kind => EFFORT[kind].hd
 function eachDoneSet(S, fn) {
   ;(S.workouts || []).forEach(w =>
     (w.entries || []).forEach(e =>
-      (e.sets || []).forEach(s => { if (s.done && !s.warmup) fn(s, w, e) })))
+      (e.sets || []).forEach(s => { if (s.done && !isWarmupRow(s)) fn(s, w, e) })))
 }
 
 // A window in days, counted back from now. 0 = everything, which is also what an empty

--- a/frontend/src/lib/effort.test.js
+++ b/frontend/src/lib/effort.test.js
@@ -116,6 +116,17 @@ describe('effortSummary', () => {
   it('survives a profile with no training at all', () => {
     expect(effortSummary({ workouts: [] }, 30)).toEqual({ done: 0, rated: 0, hard: 0, avg: null, hardPct: null })
   })
+
+  it('uses phase as authoritative while retaining legacy boolean warm-up fallback', () => {
+    const summary = effortSummary(S(W(1, [
+      { rir: 0, phase: 'warmup' },
+      { rir: 1, phase: 'work', warmup: true },
+      { rir: 2 }, { rir: 2 }, { rir: 2 }, { rir: 2 },
+    ])), 0)
+    expect(summary.done).toBe(5)
+    expect(summary.rated).toBe(5)
+    expect(summary.hard).toBe(5)
+  })
 })
 
 describe('hasEffort', () => {

--- a/frontend/src/lib/history.js
+++ b/frontend/src/lib/history.js
@@ -1,6 +1,7 @@
 // Pure helpers over the state object S (ported 1:1 from the vanilla app).
 import { todayISO, isoOf, weekKey, fmtNum } from './format.js'
 import { isCardio, isBodyweightEq } from './exercises.js'
+import { isWarmupRow } from './workout-model.js'
 // i18n-core, not i18n: this file is imported by mcp/, which is plain Node with no Vite and no
 // React. i18n.js is the Vite half — import.meta.glob over the locale packs, useSyncExternalStore
 // for the hook — and it re-exports this very `t` from core, so nothing changes here except what
@@ -330,7 +331,7 @@ export function streakWeeks(S) {
  * undone take the new value (null deletes the key). Done sets are never rewritten.
  */
 export function cascadeWeight(rows, from, value) {
-  const warm = !!rows[from]?.warmup
+  const warm = isWarmupRow(rows[from])
   const next = rows.slice()
   for (let j = from + 1; j < next.length; j++) {
     if (!!next[j].warmup === warm && !next[j].done) {
@@ -343,7 +344,7 @@ export function cascadeWeight(rows, from, value) {
 
 /** Insert a warm-up row before the first work row, copying the preceding warm-up's values. */
 export function insertWarmupRow(rows, mode, target) {
-  const firstWork = rows.findIndex(x => !x.warmup)
+  const firstWork = rows.findIndex(x => !isWarmupRow(x))
   const at = firstWork === -1 ? rows.length : firstWork
   const l = rows[at - 1] || rows[rows.length - 1]
   const warm = mode === 'cardio'

--- a/frontend/src/lib/history.test.js
+++ b/frontend/src/lib/history.test.js
@@ -9,49 +9,6 @@ const CARDIO = EXDB.find(e => e.bp === 'cardio').id
 const LIFT = EXDB.find(e => e.bp !== 'cardio' && e.eq !== 'body weight').id
 const BW = EXDB.find(e => e.eq === 'body weight').id
 
-describe('superset editing', () => {
-  it('pairs adjacent entries without mutating the source and keeps the display units contiguous', () => {
-    const entries = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
-
-    const paired = pairAdjacent(entries, 1, 2, 'sg-new')
-
-    expect(paired).toEqual([{ id: 'a' }, { id: 'b', sg: 'sg-new' }, { id: 'c', sg: 'sg-new' }])
-    expect(entries).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
-    expect(supersetUnits(paired)).toEqual([[0], [1, 2]])
-  })
-
-  it('merges both contiguous groups when their boundary entries are paired', () => {
-    const entries = [
-      { id: 'a', sg: 'left' }, { id: 'b', sg: 'left' },
-      { id: 'c', sg: 'right' }, { id: 'd', sg: 'right' }
-    ]
-
-    const merged = pairAdjacent(entries, 1, 2)
-
-    expect(merged.map(e => e.sg)).toEqual(['left', 'left', 'left', 'left'])
-    expect(entries.map(e => e.sg)).toEqual(['left', 'left', 'right', 'right'])
-  })
-
-  it('unpairs one entry and removes sg values left without an adjacent partner', () => {
-    const entries = [
-      { id: 'a', sg: 'group' }, { id: 'b', sg: 'group' }, { id: 'c', sg: 'group' },
-      { id: 'd', sg: 'orphan' }
-    ]
-
-    const unpaired = unpairSuperset(entries, 1)
-
-    expect(unpaired).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }])
-    expect(entries.map(e => e.sg)).toEqual(['group', 'group', 'group', 'orphan'])
-  })
-
-  it('rejects a non-adjacent pairing request', () => {
-    const entries = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
-
-    expect(() => pairAdjacent(entries, 0, 2, 'sg-invalid')).toThrow(/adjacent/)
-    expect(entries).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
-  })
-})
-
 describe('modeOf', () => {
   it('falls back to the body part when a plan has no mode — every existing plan keeps working', () => {
     expect(modeOf({ id: CARDIO })).toBe('cardio')
@@ -519,6 +476,46 @@ describe('workoutVolume', () => {
   it('leaves an unloaded bodyweight set at zero volume rather than inventing a number', () => {
     const w = { entries: [{ id: BW, target: { bodyweight: true }, sets: [{ w: 0, r: 20, done: true }] }] }
     expect(workoutVolume(w)).toBe(0)
+  })
+})
+
+describe('superset editing', () => {
+  it('pairs adjacent entries without mutating the source and keeps the display units contiguous', () => {
+    const entries = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+    const paired = pairAdjacent(entries, 1, 2, 'sg-new')
+
+    expect(paired).toEqual([{ id: 'a' }, { id: 'b', sg: 'sg-new' }, { id: 'c', sg: 'sg-new' }])
+    expect(entries).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
+    expect(supersetUnits(paired)).toEqual([[0], [1, 2]])
+  })
+
+  it('merges both contiguous groups when their boundary entries are paired', () => {
+    const entries = [
+      { id: 'a', sg: 'left' }, { id: 'b', sg: 'left' },
+      { id: 'c', sg: 'right' }, { id: 'd', sg: 'right' }
+    ]
+    const merged = pairAdjacent(entries, 1, 2)
+
+    expect(merged.map(e => e.sg)).toEqual(['left', 'left', 'left', 'left'])
+    expect(entries.map(e => e.sg)).toEqual(['left', 'left', 'right', 'right'])
+  })
+
+  it('unpairs one entry and removes sg values left without an adjacent partner', () => {
+    const entries = [
+      { id: 'a', sg: 'group' }, { id: 'b', sg: 'group' }, { id: 'c', sg: 'group' },
+      { id: 'd', sg: 'orphan' }
+    ]
+    const unpaired = unpairSuperset(entries, 1)
+
+    expect(unpaired).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }])
+    expect(entries.map(e => e.sg)).toEqual(['group', 'group', 'group', 'orphan'])
+  })
+
+  it('rejects a non-adjacent pairing request', () => {
+    const entries = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+
+    expect(() => pairAdjacent(entries, 0, 2, 'sg-invalid')).toThrow(/adjacent/)
+    expect(entries).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
   })
 })
 

--- a/frontend/src/lib/import-csv.js
+++ b/frontend/src/lib/import-csv.js
@@ -20,6 +20,7 @@
 
 import { EXDB, EXIDX } from './exercises.js'
 import { uid } from './format.js'
+import { isWarmupRow } from './workout-model.js'
 
 /* ----------------------------------------------------------------- CSV ---- */
 
@@ -345,7 +346,8 @@ export function parseWorkoutCSV(text, { unit = 'kg' } = {}) {
       ? num(cell(r, 'distanceKm'))
       : toKm(cell(r, 'distance'), cell(r, 'distanceUnit'))
     if (!w && !reps && !mins && !km) { skipped++; continue }
-    if (/warm/i.test(cell(r, 'setType'))) warmups++
+    const warmup = /warm/i.test(cell(r, 'setType'))
+    if (warmup) warmups++
 
     const key = keyOf(name)
     let id = resolved.get(key)
@@ -368,8 +370,8 @@ export function parseWorkoutCSV(text, { unit = 'kg' } = {}) {
     // `u` carries the row's own unit into the conversion pass below and is dropped there —
     // it never reaches the stored set.
     const set = isCardio
-      ? { min: mins || 0, speed: mins > 0 ? Math.round(km / (mins / 60) * 10) / 10 : 0, done: true }
-      : { w, r: reps || 0, done: true, u: rowUnit }
+      ? { min: mins || 0, speed: mins > 0 ? Math.round(km / (mins / 60) * 10) / 10 : 0, done: true, ...(warmup ? { phase: 'warmup' } : {}) }
+      : { w, r: reps || 0, done: true, u: rowUnit, ...(warmup ? { phase: 'warmup' } : {}) }
     // Effort rides along only where the app can show it again: a weighted rep set. A treadmill
     // row with an RPE would have nowhere to put it. A set is kept on one scale, so a file
     // carrying both columns is read as RIR — the same precedence setLabel reads them back with.
@@ -416,7 +418,7 @@ export function parseWorkoutCSV(text, { unit = 'kg' } = {}) {
     const day = byDate.get(d)
     const entries = [...day.ex.entries()].map(([id, ss]) => {
       const conv2 = ss.map(({ u, ...s }) => (s.w !== undefined ? { ...s, w: convRow({ ...s, u }) } : s))
-      const mx = Math.max(0, ...conv2.map(s => s.w || 0))
+      const mx = Math.max(0, ...conv2.filter(s => !isWarmupRow(s)).map(s => s.w || 0))
       return { id, sets: conv2, topW: mx || null }
     })
     const base = new Date(d + 'T00:00:00').getTime()

--- a/frontend/src/lib/import-csv.test.js
+++ b/frontend/src/lib/import-csv.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { parseWorkoutCSV } from './import-csv.js'
+
+const CSV = [
+  'Date,Exercise,Weight,Reps,Set Type',
+  '2026-08-08,Bench Press,100,5,Warm-up',
+  '2026-08-08,Bench Press,80,5,Working',
+].join('\n')
+
+describe('CSV warm-up provenance', () => {
+  it('retains the imported warm-up phase and excludes it from topW', () => {
+    const parsed = parseWorkoutCSV(CSV, { unit: 'kg' })
+    const entry = parsed.workouts[0].entries[0]
+
+    expect(parsed.warmups).toBe(1)
+    expect(entry.sets).toEqual([
+      { w: 100, r: 5, done: true, phase: 'warmup' },
+      { w: 80, r: 5, done: true },
+    ])
+    expect(entry.topW).toBe(80)
+  })
+})

--- a/frontend/src/lib/muscles.js
+++ b/frontend/src/lib/muscles.js
@@ -8,6 +8,7 @@
 // ankles, "cardiovascular system") maps to null and is dropped rather than guessed at.
 
 import { EXIDX , smOf } from './exercises.js'
+import { isWarmupRow } from './workout-model.js'
 
 // The muscles a map can shade, in head-to-toe order — also the order of any list
 // built from them, so "what am I neglecting" reads top-down like a body.
@@ -108,7 +109,7 @@ export function loadOf(items) {
  */
 export const loadOfWorkouts = (workouts, pick) =>
   loadOf((workouts || []).flatMap(w =>
-    (w.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && !s.warmup && (!pick || pick(s))).length }))))
+    (w.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && !isWarmupRow(s) && (!pick || pick(s))).length }))))
 
 /** Load a routine *would* produce, from its planned set counts. */
 export const loadOfRoutine = routine =>
@@ -116,7 +117,7 @@ export const loadOfRoutine = routine =>
 
 /** Load for a workout still in progress — the sets ticked so far. */
 export const loadOfActive = active =>
-  loadOf((active?.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && !s.warmup).length })))
+  loadOf((active?.entries || []).map(e => ({ id: e.id, sets: (e.sets || []).filter(s => s.done && !isWarmupRow(s)).length })))
 
 /**
  * Shade buckets 0–4 per muscle.

--- a/frontend/src/lib/muscles.test.js
+++ b/frontend/src/lib/muscles.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { EXIDX, EXDB, smOf } from './exercises.js'
-import { musclesOf } from './muscles.js'
+import { loadOfWorkouts, musclesOf } from './muscles.js'
 
 // The catalogue keeps the source dataset's secondary-muscle spellings; musclesOf maps
 // those aliases to the canonical body-map slugs and applies the 0.4 support weight.
@@ -40,5 +40,23 @@ describe('catalogue secondary additions', () => {
     expect(smOf(raw)).toContain('rear deltoids')
     // the alias collapses onto the deltoids slug in the canonical muscle map
     expect(musclesOf(raw)).toHaveProperty('deltoids')
+  })
+})
+
+
+describe('map load with warm-up phases', () => {
+  it('excludes warm-up sets from the by-sets-worked map', () => {
+    const w = {
+      id: 'w1', d: '2026-08-01', start: Date.UTC(2026, 7, 1, 10), unit: 'kg',
+      entries: [{
+        id: '0025',
+        sets: [
+          { done: true, phase: 'warmup', w: 20, r: 8 },
+          { done: true, phase: 'work', w: 60, r: 8 },
+        ],
+      }],
+    }
+    const load = loadOfWorkouts([w], null)
+    expect(load.chest).toBe(1)
   })
 })

--- a/frontend/src/lib/onerm.js
+++ b/frontend/src/lib/onerm.js
@@ -1,3 +1,4 @@
+import { isWarmupRow } from './workout-model.js'
 // Estimated one-rep max (issue #18).
 //
 // Deliberately knows nothing about the exercise database: an estimate needs a weight AND a
@@ -44,7 +45,7 @@ export function estimate1RM(w, r, formula = DEFAULT_FORMULA) {
 export function bestSetOf(entry, formula = DEFAULT_FORMULA) {
   let best = null
   ;(entry?.sets || []).forEach(s => {
-    if (!s.done || s.warmup) return
+    if (!s.done || isWarmupRow(s)) return
     const est = estimate1RM(s.w, s.r, formula)
     if (est !== null && (!best || est > best.est)) best = { est, w: Number(s.w), r: Math.round(Number(s.r)) }
   })

--- a/frontend/src/lib/progression.js
+++ b/frontend/src/lib/progression.js
@@ -18,6 +18,7 @@
 
 import { modeOf, repStep } from './history.js'
 import { EXIDX } from './exercises.js'
+import { isWarmupRow } from './workout-model.js'
 
 export const POLICIES = ['off', 'linear', 'greyskull', 'double', 'time']
 
@@ -103,7 +104,7 @@ export function readSession(entry, fallback) {
   const mode = modeOf({ ...target, id: entry && entry.id })
   // Warm-up rows are prep, not the session: one filtered read beats guarding every consumer
   // below (an undone warm-up otherwise poisons `ok` forever and its reps drag `low`/`count`).
-  const sets = ((entry && entry.sets) || []).filter(s => !s.warmup)
+  const sets = ((entry && entry.sets) || []).filter(s => !isWarmupRow(s))
   const planned = target.sets || sets.length
   const enough = sets.length >= planned
 
@@ -134,7 +135,7 @@ export function sessionsFor(S, exId, fallback) {
   const out = []
   ;(S.workouts || []).forEach(w => {
     const entry = w.entries.find(e => e.id === exId)
-    if (entry && entry.sets.some(s => s.done && !s.warmup)) out.push({ d: w.d, ...readSession(entry, fallback) })
+    if (entry && entry.sets.some(s => s.done && !isWarmupRow(s))) out.push({ d: w.d, ...readSession(entry, fallback) })
   })
   return out
 }
@@ -255,7 +256,7 @@ export function applyPrescription(sets, p) {
     // Never rewrite a logged set, and never rewrite a warm-up: the prescription speaks to
     // the work rows only (a ticked warm-up falling through here would be the data-loss the
     // cascade fix removed, two files over).
-    if (s.done || s.warmup) return s
+    if (s.done || isWarmupRow(s)) return s
     const o = { ...s }
     if (p.weight != null) o.w = p.weight
     if (p.reps != null) o.r = p.reps
@@ -265,7 +266,7 @@ export function applyPrescription(sets, p) {
   // A policy that decided on a set count gets to grow the list — bodyweight progression adds
   // a set where a barbell would have added a plate. Only ever upwards, and only by copying a
   // row that is already there: a session in progress must not lose a set it has logged.
-  const workRows = out.filter(s => !s.warmup)
+  const workRows = out.filter(s => !isWarmupRow(s))
   if (p.sets > workRows.length) {
     // An all-warm-up entry has no work row to seed growth from - growing warm-up copies
     // would both invent work and never terminate the loop. Leave the entry untouched.

--- a/frontend/src/lib/progression.test.js
+++ b/frontend/src/lib/progression.test.js
@@ -476,6 +476,17 @@ describe('warm-up rows in session reads (round 3)', () => {
     expect(s.held).toEqual([45, 30])
     expect(s.ok).toBe(false) // the 30s work row is the miss, not the warm-up
   })
+
+  it('uses phase as authoritative and falls back to the legacy warm-up flag', () => {
+    const s = readSession({ id: LIFT, target: { sets: 1, reps: 5 }, sets: [
+      { phase: 'warmup', w: 120, r: 20, done: true },
+      { phase: 'work', warmup: true, w: 60, r: 5, done: true },
+    ] })
+    expect(s.count).toBe(1)
+    expect(s.weight).toBe(60)
+    expect(s.low).toBe(5)
+    expect(s.ok).toBe(true)
+  })
 })
 
 describe('applyPrescription never touches warm-up rows (round 3)', () => {

--- a/frontend/src/lib/workout-model.js
+++ b/frontend/src/lib/workout-model.js
@@ -1,0 +1,22 @@
+// Focused workout semantics shared by session, history, and strength views.
+// Legacy records have no explicit phase or mode, so the defaults preserve main's work/reps shape.
+
+const objectOf = value => value && typeof value === 'object' && !Array.isArray(value) ? value : {}
+
+function normalizedPhase(value, fallback = 'work') {
+  const token = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  if (token === 'warmup' || token === 'warm-up' || token === 'warm_up') return 'warmup'
+  if (token === 'work') return 'work'
+  return fallback === 'warmup' ? 'warmup' : 'work'
+}
+
+/** Resolve a row's phase. An explicit phase wins over the legacy warmup boolean. */
+export function phaseForSet(set, fallback = 'work') {
+  const source = objectOf(set)
+  if (source.phase != null && source.phase !== '') return normalizedPhase(source.phase, fallback)
+  return source.warmup === true ? 'warmup' : normalizedPhase(undefined, fallback)
+}
+
+export function isWarmupRow(set) {
+  return phaseForSet(set) === 'warmup'
+}

--- a/frontend/src/sheets.jsx
+++ b/frontend/src/sheets.jsx
@@ -20,6 +20,7 @@ import { buildPlanBundle, parsePlan, mergePlan, printPlan } from './lib/plan-sha
 import { estimate1RM, best1RM, is1RMRecord, REP_CAP } from './lib/onerm.js'
 import { nextPrescription, applyPrescription, policyFor, defaultIncrement, POLICIES_FOR, POLICY_NAME, POLICY_DESC, MAX_BW_SETS } from './lib/progression.js'
 import { MOBILE, shareExport } from './lib/mobile.js'
+import { isWarmupRow } from './lib/workout-model.js'
 
 const S = () => useStore.getState().S
 const update = (...a) => useStore.getState().update(...a)
@@ -849,7 +850,7 @@ function TopWeight({ entryIdx, close }) {
   // to sit after every one of them.
   const entry = A ? A.entries[entryIdx] : null
   const ex = entry && EXIDX[entry.id]
-  const maxSet = entry ? Math.max(0, ...entry.sets.filter(s => s.done).map(s => s.w || 0)) : 0
+  const maxSet = entry ? Math.max(0, ...entry.sets.filter(s => s.done && !isWarmupRow(s)).map(s => s.w || 0)) : 0
   const prevBest = entry ? Math.max((st.exWeights[entry.id] || {}).w || 0, bestWeightFor(st, entry.id)) : 0
   const [v, setV] = useState(entry ? (Math.max(maxSet, prevBest) || entry.target.weight || 0) : 0)
   useEffect(() => { if (!entry) close() }, [!entry])
@@ -939,7 +940,7 @@ function doFinishWorkout() {
   const prs = []
   const e1prs = []
   A.entries.forEach(e => {
-    const mx = Math.max(0, ...e.sets.filter(s => s.done).map(s => s.w))
+    const mx = Math.max(0, ...e.sets.filter(s => s.done && !isWarmupRow(s)).map(s => s.w))
     if (mx > 0 && mx > bestWeightFor(st, e.id)) prs.push(e.id)
     // A heavier estimate without a heavier top set is its own kind of progress —
     // same weight for more reps. Reported separately so it can't be read as a load PR.

--- a/frontend/src/views/Workout.jsx
+++ b/frontend/src/views/Workout.jsx
@@ -14,6 +14,7 @@ import Icon from '../components/Icon.jsx'
 import { Button, Check, NumberField } from '../components/ui.jsx'
 import { nextPrescription, applyPrescription } from '../lib/progression.js'
 import { glyphOf } from '../lib/glyphs.js'
+import { isWarmupRow } from '../lib/workout-model.js'
 
 /* ---------- start chooser (no active workout) ---------- */
 function StartChooser() {
@@ -136,13 +137,14 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
       {/* the header carries the same eff3 sizing as the rows, or the labels drift off their columns */}
       <div className={'sethead' + (col3 ? ' eff3' : '')}><span className="n-sp" /><span className="w-sp">{col1.hd}</span>{col2 && <span className="r-sp">{col2.hd}</span>}{col3 && <span className="eff-sp">{col3.hd}</span>}{timed && <span className="ck-sp" />}<span className="ck-sp" /></div>
       {entry.sets.map((s, i) => {
-        const warmBefore = i > 0 && !!entry.sets[i - 1].warmup
-        const isFirstWarmup = !!s.warmup && !warmBefore
+        const warm = isWarmupRow(s)
+        const warmBefore = i > 0 && isWarmupRow(entry.sets[i - 1])
+        const isFirstWarmup = warm && !warmBefore
         // Numbering restarts per phase: with two warm-ups the first work set reads 1, not 3.
-        const phaseNum = entry.sets.slice(0, i + 1).filter(x => (x.warmup === true) === (s.warmup === true)).length
+        const phaseNum = entry.sets.slice(0, i + 1).filter(x => isWarmupRow(x) === warm).length
         return <div key={i}>
           {isFirstWarmup && <div className="setph">{t('Warm-up')}</div>}
-          {!s.warmup && warmBefore && <div className="setsep" />}
+          {!warm && warmBefore && <div className="setsep" />}
           <div className={'setrow' + (s.done ? ' done' : '') + (col3 ? ' eff3' : '')}>
             <div className="n">{phaseNum}</div>
             {cell(s, i, col1, 'w')}
@@ -152,7 +154,7 @@ function ExerciseBlock({ entryIdx, compact, onToggle, onField, onAddSet, onRemov
                 set off itself. The checkbox stays for anyone who timed it on their own watch. */}
             {timed && <button className="setgo" aria-label={t('Start set')} disabled={s.done || !!working}
               onClick={() => onStartTimed(i)}><Icon name="play" /></button>}
-            {s.warmup && <button className="iconbtn" style={{ fontSize: 13 }} aria-label={t('Remove set')}
+            {warm && <button className="iconbtn" style={{ fontSize: 13 }} aria-label={t('Remove set')}
               disabled={entry.sets.length <= 1} onClick={() => onRemoveSetAt(i)}><Icon name="xmark" /></button>}
             <Check checked={s.done} onChange={() => onToggle(i)} />
           </div>


### PR DESCRIPTION
Hi! Second slice of the #86 split (your item 2 — "that part is correct and I'll merge it same day").

- New `workout-model.js` with only the phase part: `phaseForSet` / `isWarmupRow` (~15 lines). Explicit phase wins; legacy `warmup: true` is the fallback, so no existing record is reinterpreted.
- Mechanical `!s.warmup` → `!isWarmupRow(s)` swaps in `effort.js`, `onerm.js`, `progression.js`, `muscles.js`, `history.js`, `import-csv.js`, `sheets.jsx`, `Workout.jsx`. `import-csv.js` also stamps `phase: 'warmup'` on imported warm-up rows going forward.
- The `superset editing` test suite is restored, byte-identical to the previous branch.
- **257/257** tests, build green.

The strength view follows next; the fatigue model stays in #55.